### PR TITLE
JCF: clang-format the files; the configs/clang_format_config file now…

### DIFF
--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -29,21 +29,23 @@ namespace appfwk {
 /**
  * @brief ModuleList for daq_application
  */
-class daq_application_constructor : public GraphConstructor {
+class daq_application_constructor : public GraphConstructor
+{
 public:
   /**
    * @brief Constructor for the daq_application_ModuleList
    * @param config_json Configuration file to be used to create the DAQModule
    * graph
    */
-  explicit daq_application_constructor(const json &config_json)
-      : config_(config_json) {}
+  explicit daq_application_constructor(const json& config_json)
+    : config_(config_json)
+  {}
 
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap &user_module_map,
-                      CommandOrderMap &command_order_map) override {
+  void ConstructGraph(DAQModuleMap& user_module_map, CommandOrderMap& command_order_map) override
+  {
     std::map<std::string, QueueConfig> queue_configuration;
-    for (auto &queue : config_["queues"].items()) {
+    for (auto& queue : config_["queues"].items()) {
       QueueConfig qc;
       qc.kind = qc.stoqk(queue.value()["kind"].get<std::string>());
       qc.size = queue.value()["size"].get<size_t>();
@@ -51,16 +53,15 @@ public:
     }
     QueueRegistry::get().configure(queue_configuration);
 
-    for (auto &module : config_["modules"].items()) {
+    for (auto& module : config_["modules"].items()) {
 
-      user_module_map[module.key()] =
-          makeModule(module.value()["user_module_type"], module.key());
+      user_module_map[module.key()] = makeModule(module.value()["user_module_type"], module.key());
       user_module_map[module.key()]->configure(module.value());
     }
 
-    for (auto &command : config_["commands"].items()) {
+    for (auto& command : config_["commands"].items()) {
       std::list<std::string> command_order;
-      for (auto &comm : command.value()) {
+      for (auto& comm : command.value()) {
         command_order.push_back(comm);
       }
       command_order_map[command.key()] = command_order;
@@ -88,11 +89,11 @@ ERS_DECLARE_ISSUE(appfwk,          // namespace
  * @param argv Arguments
  * @return Status Code
  */
-int main(int argc, char *argv[]) {
+int
+main(int argc, char* argv[])
+{
 
-  auto args =
-      dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc,
-                                                                         argv);
+  auto args = dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
 
   dunedaq::appfwk::DAQProcess theDAQProcess(args);
 

--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -29,23 +29,21 @@ namespace appfwk {
 /**
  * @brief ModuleList for daq_application
  */
-class daq_application_constructor : public GraphConstructor 
-{
+class daq_application_constructor : public GraphConstructor {
 public:
   /**
    * @brief Constructor for the daq_application_ModuleList
-   * @param config_json Configuration file to be used to create the DAQModule graph
+   * @param config_json Configuration file to be used to create the DAQModule
+   * graph
    */
-  explicit daq_application_constructor( const json & config_json)
-    : config_(config_json)
-  {}
+  explicit daq_application_constructor(const json &config_json)
+      : config_(config_json) {}
 
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap& user_module_map,
-		      CommandOrderMap& command_order_map) override
-  {
+  void ConstructGraph(DAQModuleMap &user_module_map,
+                      CommandOrderMap &command_order_map) override {
     std::map<std::string, QueueConfig> queue_configuration;
-    for (auto& queue : config_["queues"].items()) {
+    for (auto &queue : config_["queues"].items()) {
       QueueConfig qc;
       qc.kind = qc.stoqk(queue.value()["kind"].get<std::string>());
       qc.size = queue.value()["size"].get<size_t>();
@@ -53,16 +51,16 @@ public:
     }
     QueueRegistry::get().configure(queue_configuration);
 
-    for (auto& module : config_["modules"].items()) {
+    for (auto &module : config_["modules"].items()) {
 
       user_module_map[module.key()] =
-        makeModule(module.value()["user_module_type"], module.key());
+          makeModule(module.value()["user_module_type"], module.key());
       user_module_map[module.key()]->configure(module.value());
     }
 
-    for (auto& command : config_["commands"].items()) {
+    for (auto &command : config_["commands"].items()) {
       std::list<std::string> command_order;
-      for (auto& comm : command.value()) {
+      for (auto &comm : command.value()) {
         command_order.push_back(comm);
       }
       command_order_map[command.key()] = command_order;
@@ -79,7 +77,8 @@ private:
  */
 ERS_DECLARE_ISSUE(appfwk,          // namespace
                   NoConfiguration, // issue class name
-                  "No configuration file given to daq_application; re-run with daq_application -h to see options!", // message
+                  "No configuration file given to daq_application; re-run with "
+                  "daq_application -h to see options!", // message
 )
 } // namespace dunedaq
 
@@ -88,13 +87,12 @@ ERS_DECLARE_ISSUE(appfwk,          // namespace
  * @param argc Number of arguments
  * @param argv Arguments
  * @return Status Code
-*/
-int
-main(int argc, char* argv[])
-{
+ */
+int main(int argc, char *argv[]) {
 
   auto args =
-    dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
+      dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc,
+                                                                         argv);
 
   dunedaq::appfwk::DAQProcess theDAQProcess(args);
 
@@ -108,7 +106,7 @@ main(int argc, char* argv[])
   }
 
   dunedaq::appfwk::daq_application_constructor gc(json_config);
-  theDAQProcess.register_modules( gc );
+  theDAQProcess.register_modules(gc);
 
   return theDAQProcess.listen();
 }

--- a/include/appfwk/CommandFacility.hpp
+++ b/include/appfwk/CommandFacility.hpp
@@ -20,18 +20,21 @@
 #include <vector>
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
-#define EXTERN_C_FUNC_DECLARE_START extern "C" {
+#define EXTERN_C_FUNC_DECLARE_START                                                                                    \
+  extern "C"                                                                                                           \
+  {
 #endif
 
 /**
  * @brief Declare the function that will be called by the plugin loader
  * @param klass Class to be defined as a DUNE Command Facility
  */
-#define DEFINE_DUNE_COMMAND_FACILITY(klass)                                    \
-  EXTERN_C_FUNC_DECLARE_START                                                  \
-  std::unique_ptr<dunedaq::appfwk::CommandFacility> make() {                   \
-    return std::unique_ptr<dunedaq::appfwk::CommandFacility>(new klass());     \
-  }                                                                            \
+#define DEFINE_DUNE_COMMAND_FACILITY(klass)                                                                            \
+  EXTERN_C_FUNC_DECLARE_START                                                                                          \
+  std::unique_ptr<dunedaq::appfwk::CommandFacility> make()                                                             \
+  {                                                                                                                    \
+    return std::unique_ptr<dunedaq::appfwk::CommandFacility>(new klass());                                             \
+  }                                                                                                                    \
   }
 
 namespace dunedaq::appfwk {
@@ -40,13 +43,15 @@ class DAQProcess; // forward declaration
 /**
  * @brief Interface needed by Application Framework for CCM command handling
  */
-class CommandFacility {
+class CommandFacility
+{
 public:
   /**
    * @brief Singleton pattern; get a handle to the CommandFacility
    * @return Reference to the CommandFacility
    */
-  static CommandFacility &handle() {
+  static CommandFacility& handle()
+  {
     if (!handle_)
       handle_.reset(new CommandFacility());
     return *handle_;
@@ -56,9 +61,7 @@ public:
    * @brief Set the pointer returned by the handle() function
    * @param handle Handle to a loaded CommandFacility plugin
    */
-  static void setHandle(std::unique_ptr<CommandFacility> &&handle) {
-    handle_ = std::move(handle);
-  }
+  static void setHandle(std::unique_ptr<CommandFacility>&& handle) { handle_ = std::move(handle); }
   /**
    * @brief Perform basic setup actions needed by the CommandFacility, using
    * command-line arguments and environment variables
@@ -73,7 +76,7 @@ public:
    * This function should block for the lifetime of the DAQ Application, calling
    * DAQProcess::execute_command as necessary
    */
-  virtual int listen(DAQProcess *process) { return 0; }
+  virtual int listen(DAQProcess* process) { return 0; }
 
 protected:
   /**
@@ -82,8 +85,7 @@ protected:
   CommandFacility() {}
 
 private:
-  static std::unique_ptr<CommandFacility>
-      handle_; ///< Singleton pattern, handle to CommandFacility
+  static std::unique_ptr<CommandFacility> handle_; ///< Singleton pattern, handle to CommandFacility
 };
 
 /**
@@ -92,7 +94,8 @@ private:
  * @return Pointer to loaded CommandFacility from plugin
  */
 inline std::unique_ptr<CommandFacility>
-makeCommandFacility(std::string const &facility_name) {
+makeCommandFacility(std::string const& facility_name)
+{
   static cet::BasicPluginFactory bpf("duneCommandFacility", "make");
 
   return bpf.makePlugin<std::unique_ptr<CommandFacility>>(facility_name);

--- a/include/appfwk/CommandFacility.hpp
+++ b/include/appfwk/CommandFacility.hpp
@@ -20,9 +20,7 @@
 #include <vector>
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
-#define EXTERN_C_FUNC_DECLARE_START                                            \
-  extern "C"                                                                   \
-  {
+#define EXTERN_C_FUNC_DECLARE_START extern "C" {
 #endif
 
 /**
@@ -31,9 +29,8 @@
  */
 #define DEFINE_DUNE_COMMAND_FACILITY(klass)                                    \
   EXTERN_C_FUNC_DECLARE_START                                                  \
-  std::unique_ptr<dunedaq::appfwk::CommandFacility> make()                        \
-  {                                                                            \
-    return std::unique_ptr<dunedaq::appfwk::CommandFacility>(new klass());        \
+  std::unique_ptr<dunedaq::appfwk::CommandFacility> make() {                   \
+    return std::unique_ptr<dunedaq::appfwk::CommandFacility>(new klass());     \
   }                                                                            \
   }
 
@@ -43,15 +40,13 @@ class DAQProcess; // forward declaration
 /**
  * @brief Interface needed by Application Framework for CCM command handling
  */
-class CommandFacility
-{
+class CommandFacility {
 public:
   /**
    * @brief Singleton pattern; get a handle to the CommandFacility
    * @return Reference to the CommandFacility
    */
-  static CommandFacility& handle()
-  {
+  static CommandFacility &handle() {
     if (!handle_)
       handle_.reset(new CommandFacility());
     return *handle_;
@@ -61,8 +56,7 @@ public:
    * @brief Set the pointer returned by the handle() function
    * @param handle Handle to a loaded CommandFacility plugin
    */
-  static void setHandle(std::unique_ptr<CommandFacility>&& handle)
-  {
+  static void setHandle(std::unique_ptr<CommandFacility> &&handle) {
     handle_ = std::move(handle);
   }
   /**
@@ -79,7 +73,7 @@ public:
    * This function should block for the lifetime of the DAQ Application, calling
    * DAQProcess::execute_command as necessary
    */
-  virtual int listen(DAQProcess* process) { return 0; }
+  virtual int listen(DAQProcess *process) { return 0; }
 
 protected:
   /**
@@ -89,17 +83,16 @@ protected:
 
 private:
   static std::unique_ptr<CommandFacility>
-    handle_; ///< Singleton pattern, handle to CommandFacility
+      handle_; ///< Singleton pattern, handle to CommandFacility
 };
 
 /**
  * @brief Instantiate a CommandFacility from a plugin
  * @param facility_name Name of the CommandFacility plugin to load
  * @return Pointer to loaded CommandFacility from plugin
-*/
+ */
 inline std::unique_ptr<CommandFacility>
-makeCommandFacility(std::string const& facility_name)
-{
+makeCommandFacility(std::string const &facility_name) {
   static cet::BasicPluginFactory bpf("duneCommandFacility", "make");
 
   return bpf.makePlugin<std::unique_ptr<CommandFacility>>(facility_name);

--- a/include/appfwk/CommandLineInterpreter.hpp
+++ b/include/appfwk/CommandLineInterpreter.hpp
@@ -25,7 +25,8 @@ namespace dunedaq::appfwk {
  * @brief CommandLineInterpreter parses the command-line options given to the
  * application and stores the results as validated data members
  */
-struct CommandLineInterpreter {
+struct CommandLineInterpreter
+{
 public:
   /**
    * @brief Parse the command line and return a CommandLineInterpreter struct
@@ -33,8 +34,8 @@ public:
    * @param argv Command-line arguments
    * @return CommandLineInterpreter structure with parsed arguments
    */
-  static CommandLineInterpreter ParseCommandLineArguments(int argc,
-                                                          char **argv) {
+  static CommandLineInterpreter ParseCommandLineArguments(int argc, char** argv)
+  {
     CommandLineInterpreter output;
 
     std::ostringstream descstr;
@@ -42,30 +43,21 @@ public:
             << " known arguments (additional arguments will be stored and "
                "passed on)";
     bpo::options_description desc(descstr.str());
-    desc.add_options()("commandFacility,c", bpo::value<std::string>(),
-                       "CommandFacility plugin name")(
-        "configManager,m", bpo::value<std::string>(),
-        "ConfigurationManager plugin name")(
-        "service,s", bpo::value<std::vector<std::string>>(),
-        "Service plugin(s) to load")(
-        "configJson,j", bpo::value<std::string>(),
-        "JSON Application configuration file name")("help,h",
-                                                    "produce help message");
+    desc.add_options()("commandFacility,c", bpo::value<std::string>(), "CommandFacility plugin name")(
+      "configManager,m", bpo::value<std::string>(), "ConfigurationManager plugin name")(
+      "service,s", bpo::value<std::vector<std::string>>(), "Service plugin(s) to load")(
+      "configJson,j", bpo::value<std::string>(), "JSON Application configuration file name")("help,h",
+                                                                                             "produce help message");
     bpo::variables_map vm;
     try {
-      auto parsed = bpo::command_line_parser(argc, argv)
-                        .options(desc)
-                        .allow_unregistered()
-                        .run();
+      auto parsed = bpo::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
 
-      output.otherOptions =
-          bpo::collect_unrecognized(parsed.options, bpo::include_positional);
+      output.otherOptions = bpo::collect_unrecognized(parsed.options, bpo::include_positional);
       bpo::store(parsed, vm);
       bpo::notify(vm);
-    } catch (bpo::error const &e) {
+    } catch (bpo::error const& e) {
       TLOG_ERROR("CommandLineInterpreter")
-          << "Exception from command line processing in " << argv[0] << ": "
-          << e.what() << "\n";
+        << "Exception from command line processing in " << argv[0] << ": " << e.what() << "\n";
       exit(-1);
     }
 
@@ -75,17 +67,14 @@ public:
     }
 
     if (vm.count("commandFacility")) {
-      output.commandFacilityPluginName =
-          vm["commandFacility"].as<std::string>();
+      output.commandFacilityPluginName = vm["commandFacility"].as<std::string>();
     } else {
-      TLOG_ERROR("CommandLineInterpreter")
-          << "CommandFacility not specified on command line! Exiting";
+      TLOG_ERROR("CommandLineInterpreter") << "CommandFacility not specified on command line! Exiting";
       std::cout << desc; // NOLINT
       exit(-2);
     }
     if (vm.count("configManager")) {
-      output.configurationManagerPluginName =
-          vm["configManager"].as<std::string>();
+      output.configurationManagerPluginName = vm["configManager"].as<std::string>();
     }
     if (vm.count("service")) {
       output.servicePluginNames = vm["service"].as<std::vector<std::string>>();
@@ -97,18 +86,14 @@ public:
     return output;
   }
 
-  bool isValid{false}; ///< Whether the command line was successfully parsed
-  std::string applicaitonConfigurationFile; ///< File that contains application
-                                            ///< configuration (JSON)
-  std::string
-      commandFacilityPluginName; ///< Name of the CommandFacility plugin to load
-  std::string
-      configurationManagerPluginName; ///< Name of the ConfigurationManager
-                                      ///< plugin to load
-  std::vector<std::string>
-      servicePluginNames; ///< Names of the Service plugins to load
-  std::vector<std::string>
-      otherOptions; ///< Any other options which were passed and not recognized
+  bool isValid{ false };                       ///< Whether the command line was successfully parsed
+  std::string applicaitonConfigurationFile;    ///< File that contains application
+                                               ///< configuration (JSON)
+  std::string commandFacilityPluginName;       ///< Name of the CommandFacility plugin to load
+  std::string configurationManagerPluginName;  ///< Name of the ConfigurationManager
+                                               ///< plugin to load
+  std::vector<std::string> servicePluginNames; ///< Names of the Service plugins to load
+  std::vector<std::string> otherOptions;       ///< Any other options which were passed and not recognized
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/CommandLineInterpreter.hpp
+++ b/include/appfwk/CommandLineInterpreter.hpp
@@ -25,8 +25,7 @@ namespace dunedaq::appfwk {
  * @brief CommandLineInterpreter parses the command-line options given to the
  * application and stores the results as validated data members
  */
-struct CommandLineInterpreter
-{
+struct CommandLineInterpreter {
 public:
   /**
    * @brief Parse the command line and return a CommandLineInterpreter struct
@@ -34,42 +33,39 @@ public:
    * @param argv Command-line arguments
    * @return CommandLineInterpreter structure with parsed arguments
    */
-  static CommandLineInterpreter ParseCommandLineArguments(int argc, char** argv)
-  {
+  static CommandLineInterpreter ParseCommandLineArguments(int argc,
+                                                          char **argv) {
     CommandLineInterpreter output;
 
     std::ostringstream descstr;
-    descstr
-      << argv[0]
-      << " known arguments (additional arguments will be stored and passed on)";
+    descstr << argv[0]
+            << " known arguments (additional arguments will be stored and "
+               "passed on)";
     bpo::options_description desc(descstr.str());
-    desc.add_options()("commandFacility,c",
-                       bpo::value<std::string>(),
+    desc.add_options()("commandFacility,c", bpo::value<std::string>(),
                        "CommandFacility plugin name")(
-      "configManager,m",
-      bpo::value<std::string>(),
-      "ConfigurationManager plugin name")(
-      "service,s",
-      bpo::value<std::vector<std::string>>(),
-      "Service plugin(s) to load")("configJson,j",
-                                   bpo::value<std::string>(),
-                                   "JSON Application configuration file name")(
-      "help,h", "produce help message");
+        "configManager,m", bpo::value<std::string>(),
+        "ConfigurationManager plugin name")(
+        "service,s", bpo::value<std::vector<std::string>>(),
+        "Service plugin(s) to load")(
+        "configJson,j", bpo::value<std::string>(),
+        "JSON Application configuration file name")("help,h",
+                                                    "produce help message");
     bpo::variables_map vm;
     try {
       auto parsed = bpo::command_line_parser(argc, argv)
-                      .options(desc)
-                      .allow_unregistered()
-                      .run();
+                        .options(desc)
+                        .allow_unregistered()
+                        .run();
 
       output.otherOptions =
-        bpo::collect_unrecognized(parsed.options, bpo::include_positional);
+          bpo::collect_unrecognized(parsed.options, bpo::include_positional);
       bpo::store(parsed, vm);
       bpo::notify(vm);
-    } catch (bpo::error const& e) {
+    } catch (bpo::error const &e) {
       TLOG_ERROR("CommandLineInterpreter")
-        << "Exception from command line processing in " << argv[0] << ": "
-        << e.what() << "\n";
+          << "Exception from command line processing in " << argv[0] << ": "
+          << e.what() << "\n";
       exit(-1);
     }
 
@@ -80,16 +76,16 @@ public:
 
     if (vm.count("commandFacility")) {
       output.commandFacilityPluginName =
-        vm["commandFacility"].as<std::string>();
+          vm["commandFacility"].as<std::string>();
     } else {
       TLOG_ERROR("CommandLineInterpreter")
-        << "CommandFacility not specified on command line! Exiting";
+          << "CommandFacility not specified on command line! Exiting";
       std::cout << desc; // NOLINT
       exit(-2);
     }
     if (vm.count("configManager")) {
       output.configurationManagerPluginName =
-        vm["configManager"].as<std::string>();
+          vm["configManager"].as<std::string>();
     }
     if (vm.count("service")) {
       output.servicePluginNames = vm["service"].as<std::vector<std::string>>();
@@ -101,18 +97,18 @@ public:
     return output;
   }
 
-  bool isValid{ false }; ///< Whether the command line was successfully parsed
+  bool isValid{false}; ///< Whether the command line was successfully parsed
   std::string applicaitonConfigurationFile; ///< File that contains application
                                             ///< configuration (JSON)
   std::string
-    commandFacilityPluginName; ///< Name of the CommandFacility plugin to load
+      commandFacilityPluginName; ///< Name of the CommandFacility plugin to load
   std::string
-    configurationManagerPluginName; ///< Name of the ConfigurationManager plugin
-                                    ///< to load
+      configurationManagerPluginName; ///< Name of the ConfigurationManager
+                                      ///< plugin to load
   std::vector<std::string>
-    servicePluginNames; ///< Names of the Service plugins to load
+      servicePluginNames; ///< Names of the Service plugins to load
   std::vector<std::string>
-    otherOptions; ///< Any other options which were passed and not recognized
+      otherOptions; ///< Any other options which were passed and not recognized
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -23,17 +23,15 @@
 
 #include <cetlib/BasicPluginFactory.h>
 #include <cetlib/compiler_macros.h>
-#include <nlohmann/json.hpp>
 #include <ers/Issue.h>
+#include <nlohmann/json.hpp>
 
 #include <memory>
 #include <string>
 #include <vector>
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
-#define EXTERN_C_FUNC_DECLARE_START                                            \
-  extern "C"                                                                   \
-  {
+#define EXTERN_C_FUNC_DECLARE_START extern "C" {
 #endif
 
 /**
@@ -42,8 +40,7 @@
  */
 #define DEFINE_DUNE_DAQ_MODULE(klass)                                          \
   EXTERN_C_FUNC_DECLARE_START                                                  \
-  std::shared_ptr<dunedaq::appfwk::DAQModule> make(std::string n)              \
-  {                                                                            \
+  std::shared_ptr<dunedaq::appfwk::DAQModule> make(std::string n) {            \
     return std::shared_ptr<dunedaq::appfwk::DAQModule>(new klass(n));          \
   }                                                                            \
   }
@@ -66,16 +63,13 @@ namespace appfwk {
  * This header also contains the definitions of the Issues that can be
  * thrown by the DAQModule.
  */
-class DAQModule : public NamedObject
-{
+class DAQModule : public NamedObject {
 public:
   /**
    * @brief DAQModule Constructor
    * @param name Name of the DAQModule
    */
-  explicit DAQModule(std::string name)
-    : NamedObject(name)
-  {}
+  explicit DAQModule(std::string name) : NamedObject(name) {}
 
   /**
    * @brief Set the configuration for the DAQModule
@@ -99,8 +93,8 @@ public:
    *  Non-accepted commands or failure should return an ERS exception
    * indicating this result.
    */
-  virtual void execute_command(const std::string& cmd,
-                               const std::vector<std::string>& args) = 0;
+  virtual void execute_command(const std::string &cmd,
+                               const std::vector<std::string> &args) = 0;
 
 protected:
   json configuration_; ///< JSON configuration for the DAQModule
@@ -114,9 +108,8 @@ protected:
  * DebugLogger1
  * @return shared_ptr to created DAQModule instance
  */
-inline std::shared_ptr<DAQModule>
-makeModule(std::string const& plugin_name, std::string const& instance_name)
-{
+inline std::shared_ptr<DAQModule> makeModule(std::string const &plugin_name,
+                                             std::string const &instance_name) {
   static cet::BasicPluginFactory bpf("duneDAQModule", "make");
 
   return bpf.makePlugin<std::shared_ptr<DAQModule>>(plugin_name, instance_name);
@@ -127,33 +120,31 @@ makeModule(std::string const& plugin_name, std::string const& instance_name)
 /**
  * @brief A generic DAQModule ERS Issue
  */
-ERS_DECLARE_ISSUE(appfwk,
-                  GeneralDAQModuleIssue,
-                  "General DAQModule Issue",
+ERS_DECLARE_ISSUE(appfwk, GeneralDAQModuleIssue, "General DAQModule Issue",
                   ERS_EMPTY)
 
 /**
  * @brief The UnknownCommand DAQModule ERS Issue
  */
 ERS_DECLARE_ISSUE_BASE(
-  appfwk,                                    ///< Namespace
-  UnknownCommand,                            ///< Type of the issue
-  GeneralDAQModuleIssue,                     ///< Base class of the issue
-  "Command " << cmd << " is not recognised", ///< Log Message from the issue
-  ERS_EMPTY,                                 ///< End of variable declarations
-  ((std::string)cmd))                        ///< Variables to capture
+    appfwk,                                    ///< Namespace
+    UnknownCommand,                            ///< Type of the issue
+    GeneralDAQModuleIssue,                     ///< Base class of the issue
+    "Command " << cmd << " is not recognised", ///< Log Message from the issue
+    ERS_EMPTY,                                 ///< End of variable declarations
+    ((std::string)cmd))                        ///< Variables to capture
 
 /**
  * @brief The CommandFailed DAQModule ERS Issue
  */
 ERS_DECLARE_ISSUE_BASE(
-  appfwk,               ///< Namespace
-  CommandFailed,        ///< Type of the Issue
-  GeneralDAQModuleIssue, ///< Base class of the Issue
-  "Command " << cmd << " failed to execute for reason "
-             << reason,                    ///< Log Message from the issue
-  ERS_EMPTY,                               ///< End of variable declarations
-  ((std::string)cmd)((std::string)reason)) ///< Variables to capture
+    appfwk,                ///< Namespace
+    CommandFailed,         ///< Type of the Issue
+    GeneralDAQModuleIssue, ///< Base class of the Issue
+    "Command " << cmd << " failed to execute for reason "
+               << reason,                    ///< Log Message from the issue
+    ERS_EMPTY,                               ///< End of variable declarations
+    ((std::string)cmd)((std::string)reason)) ///< Variables to capture
 } // namespace dunedaq
 
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_DAQMODULE_HPP_

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -31,18 +31,21 @@
 #include <vector>
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
-#define EXTERN_C_FUNC_DECLARE_START extern "C" {
+#define EXTERN_C_FUNC_DECLARE_START                                                                                    \
+  extern "C"                                                                                                           \
+  {
 #endif
 
 /**
  * @brief Declare the function that will be called by the plugin loader
  * @param klass Class to be defined as a DUNE DAQ Module
  */
-#define DEFINE_DUNE_DAQ_MODULE(klass)                                          \
-  EXTERN_C_FUNC_DECLARE_START                                                  \
-  std::shared_ptr<dunedaq::appfwk::DAQModule> make(std::string n) {            \
-    return std::shared_ptr<dunedaq::appfwk::DAQModule>(new klass(n));          \
-  }                                                                            \
+#define DEFINE_DUNE_DAQ_MODULE(klass)                                                                                  \
+  EXTERN_C_FUNC_DECLARE_START                                                                                          \
+  std::shared_ptr<dunedaq::appfwk::DAQModule> make(std::string n)                                                      \
+  {                                                                                                                    \
+    return std::shared_ptr<dunedaq::appfwk::DAQModule>(new klass(n));                                                  \
+  }                                                                                                                    \
   }
 
 /**
@@ -63,13 +66,16 @@ namespace appfwk {
  * This header also contains the definitions of the Issues that can be
  * thrown by the DAQModule.
  */
-class DAQModule : public NamedObject {
+class DAQModule : public NamedObject
+{
 public:
   /**
    * @brief DAQModule Constructor
    * @param name Name of the DAQModule
    */
-  explicit DAQModule(std::string name) : NamedObject(name) {}
+  explicit DAQModule(std::string name)
+    : NamedObject(name)
+  {}
 
   /**
    * @brief Set the configuration for the DAQModule
@@ -93,8 +99,7 @@ public:
    *  Non-accepted commands or failure should return an ERS exception
    * indicating this result.
    */
-  virtual void execute_command(const std::string &cmd,
-                               const std::vector<std::string> &args) = 0;
+  virtual void execute_command(const std::string& cmd, const std::vector<std::string>& args) = 0;
 
 protected:
   json configuration_; ///< JSON configuration for the DAQModule
@@ -108,8 +113,9 @@ protected:
  * DebugLogger1
  * @return shared_ptr to created DAQModule instance
  */
-inline std::shared_ptr<DAQModule> makeModule(std::string const &plugin_name,
-                                             std::string const &instance_name) {
+inline std::shared_ptr<DAQModule>
+makeModule(std::string const& plugin_name, std::string const& instance_name)
+{
   static cet::BasicPluginFactory bpf("duneDAQModule", "make");
 
   return bpf.makePlugin<std::shared_ptr<DAQModule>>(plugin_name, instance_name);
@@ -120,31 +126,27 @@ inline std::shared_ptr<DAQModule> makeModule(std::string const &plugin_name,
 /**
  * @brief A generic DAQModule ERS Issue
  */
-ERS_DECLARE_ISSUE(appfwk, GeneralDAQModuleIssue, "General DAQModule Issue",
-                  ERS_EMPTY)
+ERS_DECLARE_ISSUE(appfwk, GeneralDAQModuleIssue, "General DAQModule Issue", ERS_EMPTY)
 
 /**
  * @brief The UnknownCommand DAQModule ERS Issue
  */
-ERS_DECLARE_ISSUE_BASE(
-    appfwk,                                    ///< Namespace
-    UnknownCommand,                            ///< Type of the issue
-    GeneralDAQModuleIssue,                     ///< Base class of the issue
-    "Command " << cmd << " is not recognised", ///< Log Message from the issue
-    ERS_EMPTY,                                 ///< End of variable declarations
-    ((std::string)cmd))                        ///< Variables to capture
+ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
+                       UnknownCommand,                            ///< Type of the issue
+                       GeneralDAQModuleIssue,                     ///< Base class of the issue
+                       "Command " << cmd << " is not recognised", ///< Log Message from the issue
+                       ERS_EMPTY,                                 ///< End of variable declarations
+                       ((std::string)cmd))                        ///< Variables to capture
 
 /**
  * @brief The CommandFailed DAQModule ERS Issue
  */
-ERS_DECLARE_ISSUE_BASE(
-    appfwk,                ///< Namespace
-    CommandFailed,         ///< Type of the Issue
-    GeneralDAQModuleIssue, ///< Base class of the Issue
-    "Command " << cmd << " failed to execute for reason "
-               << reason,                    ///< Log Message from the issue
-    ERS_EMPTY,                               ///< End of variable declarations
-    ((std::string)cmd)((std::string)reason)) ///< Variables to capture
+ERS_DECLARE_ISSUE_BASE(appfwk,                                                          ///< Namespace
+                       CommandFailed,                                                   ///< Type of the Issue
+                       GeneralDAQModuleIssue,                                           ///< Base class of the Issue
+                       "Command " << cmd << " failed to execute for reason " << reason, ///< Log Message from the issue
+                       ERS_EMPTY,                               ///< End of variable declarations
+                       ((std::string)cmd)((std::string)reason)) ///< Variables to capture
 } // namespace dunedaq
 
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_DAQMODULE_HPP_

--- a/include/appfwk/DAQModuleThreadHelper.hpp
+++ b/include/appfwk/DAQModuleThreadHelper.hpp
@@ -23,7 +23,8 @@ namespace dunedaq::appfwk {
  * @brief DAQModuleThreadHelper contains a thread which runs the do_work()
  * function
  */
-class DAQModuleThreadHelper {
+class DAQModuleThreadHelper
+{
 public:
   /**
    * @brief DAQModuleThreadHelper Constructor
@@ -32,13 +33,17 @@ public:
    * This constructor sets the defaults for the thread control variables
    */
   explicit DAQModuleThreadHelper(std::function<void()> do_work)
-      : thread_running_(false), working_thread_(nullptr), do_work_(do_work) {}
+    : thread_running_(false)
+    , working_thread_(nullptr)
+    , do_work_(do_work)
+  {}
 
   /**
    * @brief Start the working thread (which executes the do_work() function)
    * @throws std::runtime_error if the thread is already running
    */
-  void start_working_thread_() {
+  void start_working_thread_()
+  {
     if (thread_running()) {
       throw std::runtime_error("Attempted to start DAQModule working thread "
                                "when it is already running!");
@@ -51,7 +56,8 @@ public:
    * @throws std::runtime_error If the thread has not yet been started
    * @throws std::runtime_error If the thread is not in the joinable state
    */
-  void stop_working_thread_() {
+  void stop_working_thread_()
+  {
     if (!thread_running()) {
       throw std::runtime_error("Attempted to stop DAQModule working thread "
                                "when it is not running!");
@@ -72,14 +78,11 @@ public:
    */
   bool thread_running() const { return thread_running_.load(); }
 
-  DAQModuleThreadHelper(const DAQModuleThreadHelper &) =
-      delete; ///< DAQModuleThreadHelper is not copy-constructible
-  DAQModuleThreadHelper &operator=(const DAQModuleThreadHelper &) =
-      delete; ///< DAQModuleThreadHelper is not copy-assginable
-  DAQModuleThreadHelper(DAQModuleThreadHelper &&) =
-      delete; ///< DAQModuleThreadHelper is not move-constructible
-  DAQModuleThreadHelper &operator=(DAQModuleThreadHelper &&) =
-      delete; ///< DAQModuleThreadHelper is not move-assignable
+  DAQModuleThreadHelper(const DAQModuleThreadHelper&) = delete; ///< DAQModuleThreadHelper is not copy-constructible
+  DAQModuleThreadHelper& operator=(const DAQModuleThreadHelper&) =
+    delete;                                                ///< DAQModuleThreadHelper is not copy-assginable
+  DAQModuleThreadHelper(DAQModuleThreadHelper&&) = delete; ///< DAQModuleThreadHelper is not move-constructible
+  DAQModuleThreadHelper& operator=(DAQModuleThreadHelper&&) = delete; ///< DAQModuleThreadHelper is not move-assignable
 
 private:
   std::atomic<bool> thread_running_;

--- a/include/appfwk/DAQModuleThreadHelper.hpp
+++ b/include/appfwk/DAQModuleThreadHelper.hpp
@@ -23,8 +23,7 @@ namespace dunedaq::appfwk {
  * @brief DAQModuleThreadHelper contains a thread which runs the do_work()
  * function
  */
-class DAQModuleThreadHelper
-{
+class DAQModuleThreadHelper {
 public:
   /**
    * @brief DAQModuleThreadHelper Constructor
@@ -33,17 +32,13 @@ public:
    * This constructor sets the defaults for the thread control variables
    */
   explicit DAQModuleThreadHelper(std::function<void()> do_work)
-    : thread_running_(false)
-    , working_thread_(nullptr)
-    , do_work_(do_work)
-  {}
+      : thread_running_(false), working_thread_(nullptr), do_work_(do_work) {}
 
   /**
    * @brief Start the working thread (which executes the do_work() function)
    * @throws std::runtime_error if the thread is already running
    */
-  void start_working_thread_()
-  {
+  void start_working_thread_() {
     if (thread_running()) {
       throw std::runtime_error("Attempted to start DAQModule working thread "
                                "when it is already running!");
@@ -56,8 +51,7 @@ public:
    * @throws std::runtime_error If the thread has not yet been started
    * @throws std::runtime_error If the thread is not in the joinable state
    */
-  void stop_working_thread_()
-  {
+  void stop_working_thread_() {
     if (!thread_running()) {
       throw std::runtime_error("Attempted to stop DAQModule working thread "
                                "when it is not running!");
@@ -75,13 +69,17 @@ public:
   /**
    * @brief Determine if the thread is currently running
    * @return Whether the thread is currently running
-  */
+   */
   bool thread_running() const { return thread_running_.load(); }
 
-  DAQModuleThreadHelper(const DAQModuleThreadHelper&) = delete; ///< DAQModuleThreadHelper is not copy-constructible
-  DAQModuleThreadHelper& operator=(const DAQModuleThreadHelper&) = delete; ///< DAQModuleThreadHelper is not copy-assginable
-  DAQModuleThreadHelper(DAQModuleThreadHelper&&) = delete; ///< DAQModuleThreadHelper is not move-constructible
-  DAQModuleThreadHelper& operator=(DAQModuleThreadHelper&&) = delete; ///< DAQModuleThreadHelper is not move-assignable
+  DAQModuleThreadHelper(const DAQModuleThreadHelper &) =
+      delete; ///< DAQModuleThreadHelper is not copy-constructible
+  DAQModuleThreadHelper &operator=(const DAQModuleThreadHelper &) =
+      delete; ///< DAQModuleThreadHelper is not copy-assginable
+  DAQModuleThreadHelper(DAQModuleThreadHelper &&) =
+      delete; ///< DAQModuleThreadHelper is not move-constructible
+  DAQModuleThreadHelper &operator=(DAQModuleThreadHelper &&) =
+      delete; ///< DAQModuleThreadHelper is not move-assignable
 
 private:
   std::atomic<bool> thread_running_;

--- a/include/appfwk/DAQProcess.hpp
+++ b/include/appfwk/DAQProcess.hpp
@@ -31,7 +31,8 @@ namespace appfwk {
  * in the order defined in the CommandOrderMap received from the ModuleList
  * during register_modules.
  */
-class DAQProcess {
+class DAQProcess
+{
 public:
   /**
    * @brief DAQProcess Constructor
@@ -52,7 +53,7 @@ public:
    * needed by this DAQ Application. ConstructGraph also defines any ordering of
    * commands for DAQModules.
    */
-  void register_modules(GraphConstructor &gc);
+  void register_modules(GraphConstructor& gc);
   /**
    * @brief Execute the specified command on the loaded DAQModules
    * @param cmd Command to execute
@@ -63,8 +64,7 @@ public:
    * that list in the order specified. Then, any remaining DAQModules will
    * receive the command in an unspecified order.
    */
-  void execute_command(std::string const &cmd,
-                       std::vector<std::string> const &args = {});
+  void execute_command(std::string const& cmd, std::vector<std::string> const& args = {});
   /**
    * @brief Start the CommandFacility listener
    * @return Return code from listener
@@ -75,13 +75,10 @@ public:
    */
   int listen();
 
-  DAQProcess(const DAQProcess &) =
-      delete; ///< DAQProcess is not copy-constuctible
-  DAQProcess &
-  operator=(const DAQProcess &) = delete; ///< DAQProcess is not copy-assignable
-  DAQProcess(DAQProcess &&) = delete; ///< DAQProcess is not move-constructible
-  DAQProcess &
-  operator=(DAQProcess &&) = delete; ///< DAQProcess is not move-assignable
+  DAQProcess(const DAQProcess&) = delete;            ///< DAQProcess is not copy-constuctible
+  DAQProcess& operator=(const DAQProcess&) = delete; ///< DAQProcess is not copy-assignable
+  DAQProcess(DAQProcess&&) = delete;                 ///< DAQProcess is not move-constructible
+  DAQProcess& operator=(DAQProcess&&) = delete;      ///< DAQProcess is not move-assignable
 
 protected:
   /**
@@ -90,8 +87,7 @@ protected:
    * @param cmd Command name
    * @param args Command arguments
    */
-  void call_command_on_module(DAQModule &module, const std::string &cmd,
-                              std::vector<std::string> const &args);
+  void call_command_on_module(DAQModule& module, const std::string& cmd, std::vector<std::string> const& args);
 
 private:
   DAQModuleMap daqModuleMap_;       ///< String alias for each DAQModule
@@ -110,15 +106,13 @@ ERS_DECLARE_ISSUE(appfwk,                     ///< Namespace
 /**
  * @brief Issue thrown when the ordering for commands is not specified
  */
-ERS_DECLARE_ISSUE_BASE(
-    appfwk,                   ///< Namespace
-    CommandOrderNotSpecified, ///< Class Name for Issue
-    DAQProcessIssue,          ///< Base class for issue
-    "Command "
-        << cmd
-        << " does not have a specified propagation order ", ///< Message for
-                                                            ///< Issue
-    ERS_EMPTY, ((std::string)cmd))
+ERS_DECLARE_ISSUE_BASE(appfwk,                                                               ///< Namespace
+                       CommandOrderNotSpecified,                                             ///< Class Name for Issue
+                       DAQProcessIssue,                                                      ///< Base class for issue
+                       "Command " << cmd << " does not have a specified propagation order ", ///< Message for
+                                                                                             ///< Issue
+                       ERS_EMPTY,
+                       ((std::string)cmd))
 
 /**
  * @brief Issue thrown when an unknown exception is thrown from a command
@@ -126,10 +120,10 @@ ERS_DECLARE_ISSUE_BASE(
 ERS_DECLARE_ISSUE_BASE(appfwk,             ///< Namespace
                        ModuleThrowUnknown, ///< Class Name for Issue
                        DAQProcessIssue,    ///< Base class for issue
-                       "Module " << mod_name
-                                 << " threw an unknown exception after command "
+                       "Module " << mod_name << " threw an unknown exception after command "
                                  << cmd, ///< Message for Issue
-                       ERS_EMPTY, ((std::string)mod_name)((std::string)cmd))
+                       ERS_EMPTY,
+                       ((std::string)mod_name)((std::string)cmd))
 
 /**
  * @brief Issue thrown when a std::exception is thrown from a command
@@ -137,10 +131,9 @@ ERS_DECLARE_ISSUE_BASE(appfwk,             ///< Namespace
 ERS_DECLARE_ISSUE_BASE(appfwk,          ///< Namespace
                        ModuleThowStd,   ///< Class Name for Issue
                        DAQProcessIssue, ///< Base class for issue
-                       "Module " << mod_name
-                                 << " threw an std::exception after command "
-                                 << cmd, ///< Message for Issue
-                       ERS_EMPTY, ((std::string)mod_name)((std::string)cmd))
+                       "Module " << mod_name << " threw an std::exception after command " << cmd, ///< Message for Issue
+                       ERS_EMPTY,
+                       ((std::string)mod_name)((std::string)cmd))
 
 } // namespace dunedaq
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_DAQPROCESS_HPP_

--- a/include/appfwk/DAQProcess.hpp
+++ b/include/appfwk/DAQProcess.hpp
@@ -31,8 +31,7 @@ namespace appfwk {
  * in the order defined in the CommandOrderMap received from the ModuleList
  * during register_modules.
  */
-class DAQProcess
-{
+class DAQProcess {
 public:
   /**
    * @brief DAQProcess Constructor
@@ -53,7 +52,7 @@ public:
    * needed by this DAQ Application. ConstructGraph also defines any ordering of
    * commands for DAQModules.
    */
-  void register_modules(GraphConstructor& gc);
+  void register_modules(GraphConstructor &gc);
   /**
    * @brief Execute the specified command on the loaded DAQModules
    * @param cmd Command to execute
@@ -64,8 +63,8 @@ public:
    * that list in the order specified. Then, any remaining DAQModules will
    * receive the command in an unspecified order.
    */
-  void execute_command(std::string const& cmd,
-                       std::vector<std::string> const& args = {});
+  void execute_command(std::string const &cmd,
+                       std::vector<std::string> const &args = {});
   /**
    * @brief Start the CommandFacility listener
    * @return Return code from listener
@@ -76,13 +75,13 @@ public:
    */
   int listen();
 
-  DAQProcess(const DAQProcess&) =
-    delete; ///< DAQProcess is not copy-constuctible
-  DAQProcess& operator=(const DAQProcess&) =
-    delete;                          ///< DAQProcess is not copy-assignable
-  DAQProcess(DAQProcess&&) = delete; ///< DAQProcess is not move-constructible
-  DAQProcess& operator=(DAQProcess&&) =
-    delete; ///< DAQProcess is not move-assignable
+  DAQProcess(const DAQProcess &) =
+      delete; ///< DAQProcess is not copy-constuctible
+  DAQProcess &
+  operator=(const DAQProcess &) = delete; ///< DAQProcess is not copy-assignable
+  DAQProcess(DAQProcess &&) = delete; ///< DAQProcess is not move-constructible
+  DAQProcess &
+  operator=(DAQProcess &&) = delete; ///< DAQProcess is not move-assignable
 
 protected:
   /**
@@ -91,9 +90,8 @@ protected:
    * @param cmd Command name
    * @param args Command arguments
    */
-  void call_command_on_module(DAQModule& module,
-                              const std::string& cmd,
-                              std::vector<std::string> const& args);
+  void call_command_on_module(DAQModule &module, const std::string &cmd,
+                              std::vector<std::string> const &args);
 
 private:
   DAQModuleMap daqModuleMap_;       ///< String alias for each DAQModule
@@ -104,7 +102,7 @@ private:
 /**
  * @brief DAQ Process generic Issue
  */
-ERS_DECLARE_ISSUE(appfwk,            ///< Namespace
+ERS_DECLARE_ISSUE(appfwk,                     ///< Namespace
                   DAQProcessIssue,            ///< Type of the Issue
                   "General DAQProcess Issue", ///< Message for Issue
                   ERS_EMPTY)
@@ -113,38 +111,36 @@ ERS_DECLARE_ISSUE(appfwk,            ///< Namespace
  * @brief Issue thrown when the ordering for commands is not specified
  */
 ERS_DECLARE_ISSUE_BASE(
-  appfwk,          ///< Namespace
-  CommandOrderNotSpecified, ///< Class Name for Issue
-  DAQProcessIssue,          ///< Base class for issue
-  "Command "
-    << cmd
-    << " does not have a specified propagation order ", ///< Message for Issue
-  ERS_EMPTY,
-  ((std::string)cmd))
+    appfwk,                   ///< Namespace
+    CommandOrderNotSpecified, ///< Class Name for Issue
+    DAQProcessIssue,          ///< Base class for issue
+    "Command "
+        << cmd
+        << " does not have a specified propagation order ", ///< Message for
+                                                            ///< Issue
+    ERS_EMPTY, ((std::string)cmd))
 
 /**
  * @brief Issue thrown when an unknown exception is thrown from a command
  */
-ERS_DECLARE_ISSUE_BASE(appfwk,    ///< Namespace
+ERS_DECLARE_ISSUE_BASE(appfwk,             ///< Namespace
                        ModuleThrowUnknown, ///< Class Name for Issue
                        DAQProcessIssue,    ///< Base class for issue
                        "Module " << mod_name
                                  << " threw an unknown exception after command "
                                  << cmd, ///< Message for Issue
-                       ERS_EMPTY,
-                       ((std::string)mod_name)((std::string)cmd))
+                       ERS_EMPTY, ((std::string)mod_name)((std::string)cmd))
 
 /**
  * @brief Issue thrown when a std::exception is thrown from a command
  */
-ERS_DECLARE_ISSUE_BASE(appfwk, ///< Namespace
+ERS_DECLARE_ISSUE_BASE(appfwk,          ///< Namespace
                        ModuleThowStd,   ///< Class Name for Issue
                        DAQProcessIssue, ///< Base class for issue
                        "Module " << mod_name
                                  << " threw an std::exception after command "
                                  << cmd, ///< Message for Issue
-                       ERS_EMPTY,
-                       ((std::string)mod_name)((std::string)cmd))
+                       ERS_EMPTY, ((std::string)mod_name)((std::string)cmd))
 
 } // namespace dunedaq
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_DAQPROCESS_HPP_

--- a/include/appfwk/DAQSink.hpp
+++ b/include/appfwk/DAQSink.hpp
@@ -25,7 +25,7 @@ namespace dunedaq {
  * @brief Define an ERS Issue for when DAQSink is unable to retrieve its Queue
  * handle
  */
-ERS_DECLARE_ISSUE(appfwk,          // namespace
+ERS_DECLARE_ISSUE(appfwk,                    // namespace
                   DAQSinkConstructionFailed, // issue class name
                   "Failed to construct DAQSink \"" << name
                                                    << "\"", // no message
@@ -33,46 +33,35 @@ ERS_DECLARE_ISSUE(appfwk,          // namespace
 
 namespace appfwk {
 
-template<typename T>
-class DAQSink
-{
+template <typename T> class DAQSink {
 public:
   using value_type = T;
   using duration_type = std::chrono::milliseconds;
 
-  explicit DAQSink(const std::string & name);
-  void push(T&& element, const duration_type& timeout = duration_type::zero());
+  explicit DAQSink(const std::string &name);
+  void push(T &&element, const duration_type &timeout = duration_type::zero());
   bool can_push();
 
 private:
   std::shared_ptr<Queue<T>> queue_;
 };
 
-template<typename T>
-DAQSink<T>::DAQSink( const std::string & name)
-{
+template <typename T> DAQSink<T>::DAQSink(const std::string &name) {
   try {
     queue_ = QueueRegistry::get().get_queue<T>(name);
     TLOG(TLVL_TRACE, "DAQSink")
-      << "Queue " << name << " is at " << queue_.get();
-  } catch (QueueTypeMismatch& ex) {
+        << "Queue " << name << " is at " << queue_.get();
+  } catch (QueueTypeMismatch &ex) {
     throw DAQSinkConstructionFailed(ERS_HERE, name, ex);
   }
 }
 
-template<typename T>
-void
-DAQSink<T>::push(T&& element, const duration_type& timeout)
-{
+template <typename T>
+void DAQSink<T>::push(T &&element, const duration_type &timeout) {
   queue_->push(std::move(element), timeout);
 }
 
-template<typename T>
-bool
-DAQSink<T>::can_push()
-{
-  return queue_->can_push();
-}
+template <typename T> bool DAQSink<T>::can_push() { return queue_->can_push(); }
 
 } // namespace appfwk
 } // namespace dunedaq

--- a/include/appfwk/DAQSink.hpp
+++ b/include/appfwk/DAQSink.hpp
@@ -25,43 +25,52 @@ namespace dunedaq {
  * @brief Define an ERS Issue for when DAQSink is unable to retrieve its Queue
  * handle
  */
-ERS_DECLARE_ISSUE(appfwk,                    // namespace
-                  DAQSinkConstructionFailed, // issue class name
-                  "Failed to construct DAQSink \"" << name
-                                                   << "\"", // no message
+ERS_DECLARE_ISSUE(appfwk,                                           // namespace
+                  DAQSinkConstructionFailed,                        // issue class name
+                  "Failed to construct DAQSink \"" << name << "\"", // no message
                   ((std::string)name))
 
 namespace appfwk {
 
-template <typename T> class DAQSink {
+template<typename T>
+class DAQSink
+{
 public:
   using value_type = T;
   using duration_type = std::chrono::milliseconds;
 
-  explicit DAQSink(const std::string &name);
-  void push(T &&element, const duration_type &timeout = duration_type::zero());
+  explicit DAQSink(const std::string& name);
+  void push(T&& element, const duration_type& timeout = duration_type::zero());
   bool can_push();
 
 private:
   std::shared_ptr<Queue<T>> queue_;
 };
 
-template <typename T> DAQSink<T>::DAQSink(const std::string &name) {
+template<typename T>
+DAQSink<T>::DAQSink(const std::string& name)
+{
   try {
     queue_ = QueueRegistry::get().get_queue<T>(name);
-    TLOG(TLVL_TRACE, "DAQSink")
-        << "Queue " << name << " is at " << queue_.get();
-  } catch (QueueTypeMismatch &ex) {
+    TLOG(TLVL_TRACE, "DAQSink") << "Queue " << name << " is at " << queue_.get();
+  } catch (QueueTypeMismatch& ex) {
     throw DAQSinkConstructionFailed(ERS_HERE, name, ex);
   }
 }
 
-template <typename T>
-void DAQSink<T>::push(T &&element, const duration_type &timeout) {
+template<typename T>
+void
+DAQSink<T>::push(T&& element, const duration_type& timeout)
+{
   queue_->push(std::move(element), timeout);
 }
 
-template <typename T> bool DAQSink<T>::can_push() { return queue_->can_push(); }
+template<typename T>
+bool
+DAQSink<T>::can_push()
+{
+  return queue_->can_push();
+}
 
 } // namespace appfwk
 } // namespace dunedaq

--- a/include/appfwk/DAQSource.hpp
+++ b/include/appfwk/DAQSource.hpp
@@ -23,7 +23,7 @@ namespace dunedaq {
  * @brief Define an ERS Issue for when DAQSource is unable to retrieve its Queue
  * handle
  */
-ERS_DECLARE_ISSUE(appfwk,                     // namespace
+ERS_DECLARE_ISSUE(appfwk,                      // namespace
                   DAQSourceConstructionFailed, // issue class name
                   "Failed to construct DAQSource \"" << name
                                                      << "\"", // no message
@@ -31,46 +31,35 @@ ERS_DECLARE_ISSUE(appfwk,                     // namespace
 
 namespace appfwk {
 
-template<typename T>
-class DAQSource
-{
+template <typename T> class DAQSource {
 public:
   using value_type = T;
   using duration_type = std::chrono::milliseconds;
 
-  explicit DAQSource(const std::string& name);
-  bool pop(T&, const duration_type& timeout = duration_type::zero());
+  explicit DAQSource(const std::string &name);
+  bool pop(T &, const duration_type &timeout = duration_type::zero());
   bool can_pop();
 
 private:
   std::shared_ptr<Queue<T>> queue_;
 };
 
-template<typename T>
-DAQSource<T>::DAQSource(const std::string& name)
-{
+template <typename T> DAQSource<T>::DAQSource(const std::string &name) {
   try {
     queue_ = QueueRegistry::get().get_queue<T>(name);
     TLOG(TLVL_TRACE, "DAQSource")
-      << "Queue " << name << " is at " << queue_.get();
-  } catch (QueueTypeMismatch& ex) {
+        << "Queue " << name << " is at " << queue_.get();
+  } catch (QueueTypeMismatch &ex) {
     throw DAQSourceConstructionFailed(ERS_HERE, name, ex);
   }
 }
 
-template<typename T>
-bool
-DAQSource<T>::pop(T& val, const duration_type& timeout)
-{
+template <typename T>
+bool DAQSource<T>::pop(T &val, const duration_type &timeout) {
   return queue_->pop(val, timeout);
 }
 
-template<typename T>
-bool
-DAQSource<T>::can_pop()
-{
-  return queue_->can_pop();
-}
+template <typename T> bool DAQSource<T>::can_pop() { return queue_->can_pop(); }
 
 } // namespace appfwk
 } // namespace dunedaq

--- a/include/appfwk/DAQSource.hpp
+++ b/include/appfwk/DAQSource.hpp
@@ -23,43 +23,52 @@ namespace dunedaq {
  * @brief Define an ERS Issue for when DAQSource is unable to retrieve its Queue
  * handle
  */
-ERS_DECLARE_ISSUE(appfwk,                      // namespace
-                  DAQSourceConstructionFailed, // issue class name
-                  "Failed to construct DAQSource \"" << name
-                                                     << "\"", // no message
+ERS_DECLARE_ISSUE(appfwk,                                             // namespace
+                  DAQSourceConstructionFailed,                        // issue class name
+                  "Failed to construct DAQSource \"" << name << "\"", // no message
                   ((std::string)name))
 
 namespace appfwk {
 
-template <typename T> class DAQSource {
+template<typename T>
+class DAQSource
+{
 public:
   using value_type = T;
   using duration_type = std::chrono::milliseconds;
 
-  explicit DAQSource(const std::string &name);
-  bool pop(T &, const duration_type &timeout = duration_type::zero());
+  explicit DAQSource(const std::string& name);
+  bool pop(T&, const duration_type& timeout = duration_type::zero());
   bool can_pop();
 
 private:
   std::shared_ptr<Queue<T>> queue_;
 };
 
-template <typename T> DAQSource<T>::DAQSource(const std::string &name) {
+template<typename T>
+DAQSource<T>::DAQSource(const std::string& name)
+{
   try {
     queue_ = QueueRegistry::get().get_queue<T>(name);
-    TLOG(TLVL_TRACE, "DAQSource")
-        << "Queue " << name << " is at " << queue_.get();
-  } catch (QueueTypeMismatch &ex) {
+    TLOG(TLVL_TRACE, "DAQSource") << "Queue " << name << " is at " << queue_.get();
+  } catch (QueueTypeMismatch& ex) {
     throw DAQSourceConstructionFailed(ERS_HERE, name, ex);
   }
 }
 
-template <typename T>
-bool DAQSource<T>::pop(T &val, const duration_type &timeout) {
+template<typename T>
+bool
+DAQSource<T>::pop(T& val, const duration_type& timeout)
+{
   return queue_->pop(val, timeout);
 }
 
-template <typename T> bool DAQSource<T>::can_pop() { return queue_->can_pop(); }
+template<typename T>
+bool
+DAQSource<T>::can_pop()
+{
+  return queue_->can_pop();
+}
 
 } // namespace appfwk
 } // namespace dunedaq

--- a/include/appfwk/FanOutDAQModule.hpp
+++ b/include/appfwk/FanOutDAQModule.hpp
@@ -31,31 +31,29 @@ namespace dunedaq::appfwk {
 
 /**
  * @brief Struct used for FanOutDAQModule_test
-*/
-struct NonCopyableType
-{
+ */
+struct NonCopyableType {
   int data; ///< Integer data for NonCopyableType
   /**
    * @brief NonCopyableType Constructor
    * @param d Initialization for data member
-  */
-  explicit NonCopyableType(int d)
-    : data(d)
-  {}
-  NonCopyableType(NonCopyableType const&) = delete; ///< NonCopyableType is not copy-constructible
+   */
+  explicit NonCopyableType(int d) : data(d) {}
+  NonCopyableType(NonCopyableType const &) =
+      delete; ///< NonCopyableType is not copy-constructible
   /**
    * @brief Move Constructor for NonCopyableType
    * @param i NonCopyableType rvalue to move from
-  */
-  NonCopyableType(NonCopyableType&& i) { data = i.data; }
-  NonCopyableType& operator=(NonCopyableType const&) = delete; ///< NonCopyableType is not copy-assignable
+   */
+  NonCopyableType(NonCopyableType &&i) { data = i.data; }
+  NonCopyableType &operator=(NonCopyableType const &) =
+      delete; ///< NonCopyableType is not copy-assignable
   /**
    * @brief Move assignment operator for NonCopyableType
    * @param i NonCopyableType to move from
    * @return NonCopyableType instance
-  */
-  NonCopyableType& operator=(NonCopyableType&& i)
-  {
+   */
+  NonCopyableType &operator=(NonCopyableType &&i) {
     data = i.data;
     return *this;
   }
@@ -64,25 +62,24 @@ struct NonCopyableType
 /**
  * @brief FanOutDAQModule sends data to multiple Queues
  */
-template<typename ValueType>
-class FanOutDAQModule : public DAQModule
-{
+template <typename ValueType> class FanOutDAQModule : public DAQModule {
 public:
   /**
    * @brief FanOutDAQModule Constructor
    * @param name Name of this FanOutDAQModule instance
-  */
+   */
   explicit FanOutDAQModule(std::string name);
 
   /**
    * @brief Defines the possible modes for FanOutDAQModule
-  */
-  enum class FanOutMode
-  {
+   */
+  enum class FanOutMode {
     NotConfigured, ///< FanOutDAQModule is not configured
     Broadcast, ///< FanOutDAQModule will copy elements from input to all outputs
-    RoundRobin, ///< FanOutDAQModule will distribute elements from input to outputs in a round-robin fashion
-    FirstAvailable ///< FanOutDAQModule will distribute elements from input to the first available output
+    RoundRobin,    ///< FanOutDAQModule will distribute elements from input to
+                   ///< outputs in a round-robin fashion
+    FirstAvailable ///< FanOutDAQModule will distribute elements from input to
+                   ///< the first available output
   };
 
   /**
@@ -90,13 +87,17 @@ public:
    * @param cmd Command from DAQProcess
    * @param args Arguments for the command from DAQProcess
    */
-  void execute_command(const std::string& cmd,
-                       const std::vector<std::string>& args = {}) override;
+  void execute_command(const std::string &cmd,
+                       const std::vector<std::string> &args = {}) override;
 
-  FanOutDAQModule(const FanOutDAQModule&) = delete; ///< FanOutDAQModule is not copy-constructible
-  FanOutDAQModule& operator=(const FanOutDAQModule&) = delete; ///< FanOutDAQModule is not copy-assignable
-  FanOutDAQModule(FanOutDAQModule&&) = delete; ///< FanOutDAQModule is not move-constructible
-  FanOutDAQModule& operator=(FanOutDAQModule&&) = delete; ///< FanOutDAQModule is not move-assignable
+  FanOutDAQModule(const FanOutDAQModule &) =
+      delete; ///< FanOutDAQModule is not copy-constructible
+  FanOutDAQModule &operator=(const FanOutDAQModule &) =
+      delete; ///< FanOutDAQModule is not copy-assignable
+  FanOutDAQModule(FanOutDAQModule &&) =
+      delete; ///< FanOutDAQModule is not move-constructible
+  FanOutDAQModule &operator=(FanOutDAQModule &&) =
+      delete; ///< FanOutDAQModule is not move-assignable
 
 private:
   // Commands
@@ -108,23 +109,21 @@ private:
   // necessary, even though it's just an alias to this user module's
   // data type.
 
-  template<typename U = ValueType>
-  typename std::enable_if_t<!std::is_copy_constructible_v<U>> do_broadcast(
-    ValueType&) const
-  {
+  template <typename U = ValueType>
+  typename std::enable_if_t<!std::is_copy_constructible_v<U>>
+  do_broadcast(ValueType &) const {
     throw std::runtime_error(
-      "Broadcast mode cannot be used for non-copy-constructible types!");
+        "Broadcast mode cannot be used for non-copy-constructible types!");
   }
-  template<typename U = ValueType>
-  typename std::enable_if_t<std::is_copy_constructible_v<U>> do_broadcast(
-    ValueType& data) const
-  {
-    for (auto& o : outputQueues_) {
+  template <typename U = ValueType>
+  typename std::enable_if_t<std::is_copy_constructible_v<U>>
+  do_broadcast(ValueType &data) const {
+    for (auto &o : outputQueues_) {
       auto starttime = std::chrono::steady_clock::now();
       o->push(ValueType(data), queueTimeout_);
       auto endtime = std::chrono::steady_clock::now();
       if (std::chrono::duration_cast<decltype(queueTimeout_)>(
-            endtime - starttime) > queueTimeout_) {
+              endtime - starttime) > queueTimeout_) {
         TLOG(TLVL_WARNING) << "Timeout occurred trying to broadcast data to "
                               "output queue; data may be lost if it doesn't "
                               "make it into any other output queues, either";

--- a/include/appfwk/FanOutDAQModule.hpp
+++ b/include/appfwk/FanOutDAQModule.hpp
@@ -32,28 +32,30 @@ namespace dunedaq::appfwk {
 /**
  * @brief Struct used for FanOutDAQModule_test
  */
-struct NonCopyableType {
+struct NonCopyableType
+{
   int data; ///< Integer data for NonCopyableType
   /**
    * @brief NonCopyableType Constructor
    * @param d Initialization for data member
    */
-  explicit NonCopyableType(int d) : data(d) {}
-  NonCopyableType(NonCopyableType const &) =
-      delete; ///< NonCopyableType is not copy-constructible
+  explicit NonCopyableType(int d)
+    : data(d)
+  {}
+  NonCopyableType(NonCopyableType const&) = delete; ///< NonCopyableType is not copy-constructible
   /**
    * @brief Move Constructor for NonCopyableType
    * @param i NonCopyableType rvalue to move from
    */
-  NonCopyableType(NonCopyableType &&i) { data = i.data; }
-  NonCopyableType &operator=(NonCopyableType const &) =
-      delete; ///< NonCopyableType is not copy-assignable
+  NonCopyableType(NonCopyableType&& i) { data = i.data; }
+  NonCopyableType& operator=(NonCopyableType const&) = delete; ///< NonCopyableType is not copy-assignable
   /**
    * @brief Move assignment operator for NonCopyableType
    * @param i NonCopyableType to move from
    * @return NonCopyableType instance
    */
-  NonCopyableType &operator=(NonCopyableType &&i) {
+  NonCopyableType& operator=(NonCopyableType&& i)
+  {
     data = i.data;
     return *this;
   }
@@ -62,7 +64,9 @@ struct NonCopyableType {
 /**
  * @brief FanOutDAQModule sends data to multiple Queues
  */
-template <typename ValueType> class FanOutDAQModule : public DAQModule {
+template<typename ValueType>
+class FanOutDAQModule : public DAQModule
+{
 public:
   /**
    * @brief FanOutDAQModule Constructor
@@ -73,9 +77,10 @@ public:
   /**
    * @brief Defines the possible modes for FanOutDAQModule
    */
-  enum class FanOutMode {
+  enum class FanOutMode
+  {
     NotConfigured, ///< FanOutDAQModule is not configured
-    Broadcast, ///< FanOutDAQModule will copy elements from input to all outputs
+    Broadcast,     ///< FanOutDAQModule will copy elements from input to all outputs
     RoundRobin,    ///< FanOutDAQModule will distribute elements from input to
                    ///< outputs in a round-robin fashion
     FirstAvailable ///< FanOutDAQModule will distribute elements from input to
@@ -87,17 +92,12 @@ public:
    * @param cmd Command from DAQProcess
    * @param args Arguments for the command from DAQProcess
    */
-  void execute_command(const std::string &cmd,
-                       const std::vector<std::string> &args = {}) override;
+  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
 
-  FanOutDAQModule(const FanOutDAQModule &) =
-      delete; ///< FanOutDAQModule is not copy-constructible
-  FanOutDAQModule &operator=(const FanOutDAQModule &) =
-      delete; ///< FanOutDAQModule is not copy-assignable
-  FanOutDAQModule(FanOutDAQModule &&) =
-      delete; ///< FanOutDAQModule is not move-constructible
-  FanOutDAQModule &operator=(FanOutDAQModule &&) =
-      delete; ///< FanOutDAQModule is not move-assignable
+  FanOutDAQModule(const FanOutDAQModule&) = delete;            ///< FanOutDAQModule is not copy-constructible
+  FanOutDAQModule& operator=(const FanOutDAQModule&) = delete; ///< FanOutDAQModule is not copy-assignable
+  FanOutDAQModule(FanOutDAQModule&&) = delete;                 ///< FanOutDAQModule is not move-constructible
+  FanOutDAQModule& operator=(FanOutDAQModule&&) = delete;      ///< FanOutDAQModule is not move-assignable
 
 private:
   // Commands
@@ -109,21 +109,19 @@ private:
   // necessary, even though it's just an alias to this user module's
   // data type.
 
-  template <typename U = ValueType>
-  typename std::enable_if_t<!std::is_copy_constructible_v<U>>
-  do_broadcast(ValueType &) const {
-    throw std::runtime_error(
-        "Broadcast mode cannot be used for non-copy-constructible types!");
+  template<typename U = ValueType>
+  typename std::enable_if_t<!std::is_copy_constructible_v<U>> do_broadcast(ValueType&) const
+  {
+    throw std::runtime_error("Broadcast mode cannot be used for non-copy-constructible types!");
   }
-  template <typename U = ValueType>
-  typename std::enable_if_t<std::is_copy_constructible_v<U>>
-  do_broadcast(ValueType &data) const {
-    for (auto &o : outputQueues_) {
+  template<typename U = ValueType>
+  typename std::enable_if_t<std::is_copy_constructible_v<U>> do_broadcast(ValueType& data) const
+  {
+    for (auto& o : outputQueues_) {
       auto starttime = std::chrono::steady_clock::now();
       o->push(ValueType(data), queueTimeout_);
       auto endtime = std::chrono::steady_clock::now();
-      if (std::chrono::duration_cast<decltype(queueTimeout_)>(
-              endtime - starttime) > queueTimeout_) {
+      if (std::chrono::duration_cast<decltype(queueTimeout_)>(endtime - starttime) > queueTimeout_) {
         TLOG(TLVL_WARNING) << "Timeout occurred trying to broadcast data to "
                               "output queue; data may be lost if it doesn't "
                               "make it into any other output queues, either";

--- a/include/appfwk/GraphConstructor.hpp
+++ b/include/appfwk/GraphConstructor.hpp
@@ -21,19 +21,18 @@
 
 namespace dunedaq::appfwk {
 typedef std::map<std::string, std::shared_ptr<DAQModule>>
-  DAQModuleMap; ///< DAQModules indexed by name
+    DAQModuleMap; ///< DAQModules indexed by name
 typedef std::map<std::string, std::list<std::string>>
-  CommandOrderMap; ///< Defined DAQModule orders for commands
+    CommandOrderMap; ///< Defined DAQModule orders for commands
 
 /**
- * @brief The GraphConstructor class is the representation of a DAQModule and Queue
- * graph
+ * @brief The GraphConstructor class is the representation of a DAQModule and
+ * Queue graph
  *
  * The ConstructGraph method is responsible for configuring all Queues and
  * DAQModules for a DAQ Application
  */
-class GraphConstructor
-{
+class GraphConstructor {
 public:
   /**
    * @brief Construct the DAQModules and retrieve Queue configurations
@@ -46,8 +45,8 @@ public:
    * Queue and DAQModule instances in a DAQ Application. Additionally, any
    * requirements on command order for DAQModules should be defined here.
    */
-  virtual void ConstructGraph(DAQModuleMap& daq_module_map,
-                              CommandOrderMap& command_order_map) = 0;
+  virtual void ConstructGraph(DAQModuleMap &daq_module_map,
+                              CommandOrderMap &command_order_map) = 0;
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/GraphConstructor.hpp
+++ b/include/appfwk/GraphConstructor.hpp
@@ -20,10 +20,8 @@
 #include <string>
 
 namespace dunedaq::appfwk {
-typedef std::map<std::string, std::shared_ptr<DAQModule>>
-    DAQModuleMap; ///< DAQModules indexed by name
-typedef std::map<std::string, std::list<std::string>>
-    CommandOrderMap; ///< Defined DAQModule orders for commands
+typedef std::map<std::string, std::shared_ptr<DAQModule>> DAQModuleMap; ///< DAQModules indexed by name
+typedef std::map<std::string, std::list<std::string>> CommandOrderMap;  ///< Defined DAQModule orders for commands
 
 /**
  * @brief The GraphConstructor class is the representation of a DAQModule and
@@ -32,7 +30,8 @@ typedef std::map<std::string, std::list<std::string>>
  * The ConstructGraph method is responsible for configuring all Queues and
  * DAQModules for a DAQ Application
  */
-class GraphConstructor {
+class GraphConstructor
+{
 public:
   /**
    * @brief Construct the DAQModules and retrieve Queue configurations
@@ -45,8 +44,7 @@ public:
    * Queue and DAQModule instances in a DAQ Application. Additionally, any
    * requirements on command order for DAQModules should be defined here.
    */
-  virtual void ConstructGraph(DAQModuleMap &daq_module_map,
-                              CommandOrderMap &command_order_map) = 0;
+  virtual void ConstructGraph(DAQModuleMap& daq_module_map, CommandOrderMap& command_order_map) = 0;
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/Logger.hpp
+++ b/include/appfwk/Logger.hpp
@@ -17,14 +17,13 @@ namespace dunedaq::appfwk {
  * @brief The Logger class defines the interface necessary to configure central
  * logging within a DAQ Application.
  */
-class Logger
-{
+class Logger {
 public:
   /**
    * @brief Setup the Logger service
    * @param args Command-line arguments used to setup the Logger
    */
-  static void setup(const std::vector<std::string> & args) {}
+  static void setup(const std::vector<std::string> &args) {}
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/Logger.hpp
+++ b/include/appfwk/Logger.hpp
@@ -17,13 +17,14 @@ namespace dunedaq::appfwk {
  * @brief The Logger class defines the interface necessary to configure central
  * logging within a DAQ Application.
  */
-class Logger {
+class Logger
+{
 public:
   /**
    * @brief Setup the Logger service
    * @param args Command-line arguments used to setup the Logger
    */
-  static void setup(const std::vector<std::string> &args) {}
+  static void setup(const std::vector<std::string>& args) {}
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/NamedObject.hpp
+++ b/include/appfwk/NamedObject.hpp
@@ -16,30 +16,27 @@ namespace dunedaq::appfwk {
  * @brief A NamedObject is a DAQ object (Queue or DAQModule) which has an
  * instance name
  */
-class NamedObject
-{
+class NamedObject {
 public:
   /**
    * @brief NamedObject Constructor
    * @param name Name of this object
    */
-  explicit NamedObject(const std::string& name)
-    : name_(name)
-  {}
-  NamedObject(NamedObject const&) =
-    delete; ///< NamedObject is not copy-constructible
-  NamedObject(NamedObject&&) = default; ///< NamedObject is move-constructible
-  NamedObject& operator=(NamedObject const&) =
-    delete; ///< NamedObject is not copy-assignable
-  NamedObject& operator=(NamedObject&&) =
-    default;                        ///< NamedObject is move-assignable
-  virtual ~NamedObject() = default; ///< Default virtual destructor
+  explicit NamedObject(const std::string &name) : name_(name) {}
+  NamedObject(NamedObject const &) =
+      delete; ///< NamedObject is not copy-constructible
+  NamedObject(NamedObject &&) = default; ///< NamedObject is move-constructible
+  NamedObject &operator=(NamedObject const &) =
+      delete; ///< NamedObject is not copy-assignable
+  NamedObject &
+  operator=(NamedObject &&) = default; ///< NamedObject is move-assignable
+  virtual ~NamedObject() = default;    ///< Default virtual destructor
 
   /**
    * @brief Get the name of this NamedObejct
    * @return The name of this NamedObject
    */
-  const std::string& get_name() const { return name_; }
+  const std::string &get_name() const { return name_; }
 
 private:
   std::string name_;

--- a/include/appfwk/NamedObject.hpp
+++ b/include/appfwk/NamedObject.hpp
@@ -16,27 +16,27 @@ namespace dunedaq::appfwk {
  * @brief A NamedObject is a DAQ object (Queue or DAQModule) which has an
  * instance name
  */
-class NamedObject {
+class NamedObject
+{
 public:
   /**
    * @brief NamedObject Constructor
    * @param name Name of this object
    */
-  explicit NamedObject(const std::string &name) : name_(name) {}
-  NamedObject(NamedObject const &) =
-      delete; ///< NamedObject is not copy-constructible
-  NamedObject(NamedObject &&) = default; ///< NamedObject is move-constructible
-  NamedObject &operator=(NamedObject const &) =
-      delete; ///< NamedObject is not copy-assignable
-  NamedObject &
-  operator=(NamedObject &&) = default; ///< NamedObject is move-assignable
-  virtual ~NamedObject() = default;    ///< Default virtual destructor
+  explicit NamedObject(const std::string& name)
+    : name_(name)
+  {}
+  NamedObject(NamedObject const&) = delete;            ///< NamedObject is not copy-constructible
+  NamedObject(NamedObject&&) = default;                ///< NamedObject is move-constructible
+  NamedObject& operator=(NamedObject const&) = delete; ///< NamedObject is not copy-assignable
+  NamedObject& operator=(NamedObject&&) = default;     ///< NamedObject is move-assignable
+  virtual ~NamedObject() = default;                    ///< Default virtual destructor
 
   /**
    * @brief Get the name of this NamedObejct
    * @return The name of this NamedObject
    */
-  const std::string &get_name() const { return name_; }
+  const std::string& get_name() const { return name_; }
 
 private:
   std::string name_;

--- a/include/appfwk/Queue.hpp
+++ b/include/appfwk/Queue.hpp
@@ -31,17 +31,20 @@ namespace dunedaq::appfwk {
  * Note that while the Queue class itself is not templated on a data type (so
  * it can be included in generic containers), all implementations should be.
  */
-template <class T> class Queue : public NamedObject {
+template<class T>
+class Queue : public NamedObject
+{
 public:
-  using value_type = T; ///< Type stored in the Queue
-  using duration_type =
-      std::chrono::milliseconds; ///< Base duration type for timeouts
+  using value_type = T;                            ///< Type stored in the Queue
+  using duration_type = std::chrono::milliseconds; ///< Base duration type for timeouts
 
   /**
    * @brief Queue Constructor
    * @param name Name of the Queue instance
    */
-  explicit Queue(const std::string &name) : NamedObject(name) {}
+  explicit Queue(const std::string& name)
+    : NamedObject(name)
+  {}
 
   /**
    * @brief Push a value onto the Queue.
@@ -52,7 +55,7 @@ public:
    * If push takes longer than the timeout, implementations should throw an
    * exception.
    */
-  virtual void push(T &&val, const duration_type &timeout) = 0;
+  virtual void push(T&& val, const duration_type& timeout) = 0;
 
   /**
    * @brief Determine whether the Queue may be pushed onto
@@ -71,7 +74,7 @@ public:
    * If pop takes longer than the timeout, implementations should throw an
    * exception
    */
-  virtual bool pop(T &val, const duration_type &timeout) = 0;
+  virtual bool pop(T& val, const duration_type& timeout) = 0;
 
   /**
    * @brief Determine whether the Queue may be popped from
@@ -82,10 +85,10 @@ public:
   virtual bool can_pop() const noexcept = 0;
 
 private:
-  Queue(const Queue &) = delete;
-  Queue &operator=(const Queue &) = delete;
-  Queue(Queue &&) = default;
-  Queue &operator=(Queue &&) = default;
+  Queue(const Queue&) = delete;
+  Queue& operator=(const Queue&) = delete;
+  Queue(Queue&&) = default;
+  Queue& operator=(Queue&&) = default;
 };
 
 } // namespace dunedaq::appfwk

--- a/include/appfwk/Queue.hpp
+++ b/include/appfwk/Queue.hpp
@@ -31,37 +31,35 @@ namespace dunedaq::appfwk {
  * Note that while the Queue class itself is not templated on a data type (so
  * it can be included in generic containers), all implementations should be.
  */
-template<class T>
-class Queue : public NamedObject
-{
+template <class T> class Queue : public NamedObject {
 public:
   using value_type = T; ///< Type stored in the Queue
-  using duration_type = std::chrono::milliseconds; ///< Base duration type for timeouts
+  using duration_type =
+      std::chrono::milliseconds; ///< Base duration type for timeouts
 
   /**
    * @brief Queue Constructor
    * @param name Name of the Queue instance
-  */
-  explicit Queue(const std::string & name)
-    : NamedObject(name)
-  {}
+   */
+  explicit Queue(const std::string &name) : NamedObject(name) {}
 
   /**
    * @brief Push a value onto the Queue.
    * @param val Value to push (rvalue)
-   * @param timeout Timeout for the push operation. 
+   * @param timeout Timeout for the push operation.
    *
    * This is a pure virtual function.
-   * If push takes longer than the timeout, implementations should throw an exception.
-  */
-  virtual void push(T&& val, const duration_type& timeout) = 0;
+   * If push takes longer than the timeout, implementations should throw an
+   * exception.
+   */
+  virtual void push(T &&val, const duration_type &timeout) = 0;
 
   /**
    * @brief Determine whether the Queue may be pushed onto
    * @return True if the queue is not full, false if it is
    *
    * This is a pure virtual function
-  */
+   */
   virtual bool can_push() const noexcept = 0;
 
   /**
@@ -70,23 +68,24 @@ public:
    * @return Value popped from the Queue
    *
    * This is a pure virtual function
-   * If pop takes longer than the timeout, implementations should throw an exception
-  */
-  virtual bool pop( T & val, const duration_type& timeout) = 0;
+   * If pop takes longer than the timeout, implementations should throw an
+   * exception
+   */
+  virtual bool pop(T &val, const duration_type &timeout) = 0;
 
   /**
    * @brief Determine whether the Queue may be popped from
    * @return True if the queue is not empty, false if it is
    *
-   * This is a pure virtual function 
-  */
+   * This is a pure virtual function
+   */
   virtual bool can_pop() const noexcept = 0;
 
 private:
-  Queue(const Queue&) = delete;
-  Queue& operator=(const Queue&) = delete;
-  Queue(Queue&&) = default;
-  Queue& operator=(Queue&&) = default;
+  Queue(const Queue &) = delete;
+  Queue &operator=(const Queue &) = delete;
+  Queue(Queue &&) = default;
+  Queue &operator=(Queue &&) = default;
 };
 
 } // namespace dunedaq::appfwk

--- a/include/appfwk/QueueRegistry.hpp
+++ b/include/appfwk/QueueRegistry.hpp
@@ -25,13 +25,11 @@ namespace appfwk {
  * @brief The QueueConfig class encapsulates the basic configuration common to
  * all Queue types
  */
-struct QueueConfig
-{
+struct QueueConfig {
   /**
    * @brief Enumeration of all possible types of Queue
    */
-  enum queue_kind
-  {
+  enum queue_kind {
     kUnknown = -1,
     kStdDeQueue = 1 ///< The StdDeQueue
   };
@@ -41,19 +39,19 @@ struct QueueConfig
    * @param name Name of the Queue Type
    * @return Queue type corresponding to the name. Currently only std_deque.
    */
-  static queue_kind stoqk(const std::string& name);
+  static queue_kind stoqk(const std::string &name);
 
   QueueConfig::queue_kind kind =
-    queue_kind::kUnknown; ///< The kind of Queue represented by this QueueConfig
-  size_t size = 0;        ///< The size of the queue
+      queue_kind::kUnknown; ///< The kind of Queue represented by this
+                            ///< QueueConfig
+  size_t size = 0;          ///< The size of the queue
 };
 
 /**
  * @brief The QueueRegistry class manages all Queue instances and gives out
  * handles to the Queues upon request
  */
-class QueueRegistry
-{
+class QueueRegistry {
 public:
   /**
    * @brief QueueRegistry destructor
@@ -64,7 +62,7 @@ public:
    * @brief Get a handle to the QueueRegistry
    * @return QueueRegistry handle
    */
-  static QueueRegistry& get();
+  static QueueRegistry &get();
 
   /**
    * @brief Get a handle to a Queue
@@ -72,39 +70,38 @@ public:
    * @param name Name of the Queue
    * @return std::shared_ptr to generic queue pointer
    */
-  template<typename T>
-  std::shared_ptr<Queue<T>> get_queue(const std::string& name);
+  template <typename T>
+  std::shared_ptr<Queue<T>> get_queue(const std::string &name);
 
   /**
    * @brief Configure the QueueRegistry
    * @param configmap Map relating Queue names to their configurations
    */
-  void configure(const std::map<std::string, QueueConfig>& configmap);
+  void configure(const std::map<std::string, QueueConfig> &configmap);
 
 private:
-  struct QueueEntry
-  {
-    const std::type_info* type;
+  struct QueueEntry {
+    const std::type_info *type;
     std::shared_ptr<NamedObject> instance;
   };
 
   QueueRegistry();
 
-  template<typename T>
+  template <typename T>
   std::shared_ptr<NamedObject> create_queue(std::string name,
-                                            const QueueConfig& config);
+                                            const QueueConfig &config);
 
   std::map<std::string, QueueEntry> queue_registry_;
   std::map<std::string, QueueConfig> queue_configmap_;
 
   bool configured_;
 
-  static QueueRegistry* me_;
+  static QueueRegistry *me_;
 
-  QueueRegistry(const QueueRegistry&) = delete;
-  QueueRegistry& operator=(const QueueRegistry&) = delete;
-  QueueRegistry(QueueRegistry&&) = delete;
-  QueueRegistry& operator=(QueueRegistry&&) = delete;
+  QueueRegistry(const QueueRegistry &) = delete;
+  QueueRegistry &operator=(const QueueRegistry &) = delete;
+  QueueRegistry(QueueRegistry &&) = delete;
+  QueueRegistry &operator=(QueueRegistry &&) = delete;
 };
 
 } // namespace appfwk
@@ -112,13 +109,14 @@ private:
 /**
  * @brief QueueTypeMismatch ERS Issue
  */
-ERS_DECLARE_ISSUE(
-  appfwk,            // namespace
-  QueueTypeMismatch, // issue class name
-  "Requested queue \"" << queue_name << "\" of type '" << target_type
-                       << "' already declared as type '" << source_type
-                       << "'", // message
-  ((std::string)queue_name)((std::string)source_type)((std::string)target_type))
+ERS_DECLARE_ISSUE(appfwk,            // namespace
+                  QueueTypeMismatch, // issue class name
+                  "Requested queue \""
+                      << queue_name << "\" of type '" << target_type
+                      << "' already declared as type '" << source_type
+                      << "'", // message
+                  ((std::string)queue_name)((std::string)source_type)(
+                      (std::string)target_type))
 
 /**
  * @brief QueueKindUnknown ERS Issue

--- a/include/appfwk/QueueRegistry.hpp
+++ b/include/appfwk/QueueRegistry.hpp
@@ -25,11 +25,13 @@ namespace appfwk {
  * @brief The QueueConfig class encapsulates the basic configuration common to
  * all Queue types
  */
-struct QueueConfig {
+struct QueueConfig
+{
   /**
    * @brief Enumeration of all possible types of Queue
    */
-  enum queue_kind {
+  enum queue_kind
+  {
     kUnknown = -1,
     kStdDeQueue = 1 ///< The StdDeQueue
   };
@@ -39,19 +41,19 @@ struct QueueConfig {
    * @param name Name of the Queue Type
    * @return Queue type corresponding to the name. Currently only std_deque.
    */
-  static queue_kind stoqk(const std::string &name);
+  static queue_kind stoqk(const std::string& name);
 
-  QueueConfig::queue_kind kind =
-      queue_kind::kUnknown; ///< The kind of Queue represented by this
-                            ///< QueueConfig
-  size_t size = 0;          ///< The size of the queue
+  QueueConfig::queue_kind kind = queue_kind::kUnknown; ///< The kind of Queue represented by this
+                                                       ///< QueueConfig
+  size_t size = 0;                                     ///< The size of the queue
 };
 
 /**
  * @brief The QueueRegistry class manages all Queue instances and gives out
  * handles to the Queues upon request
  */
-class QueueRegistry {
+class QueueRegistry
+{
 public:
   /**
    * @brief QueueRegistry destructor
@@ -62,7 +64,7 @@ public:
    * @brief Get a handle to the QueueRegistry
    * @return QueueRegistry handle
    */
-  static QueueRegistry &get();
+  static QueueRegistry& get();
 
   /**
    * @brief Get a handle to a Queue
@@ -70,38 +72,38 @@ public:
    * @param name Name of the Queue
    * @return std::shared_ptr to generic queue pointer
    */
-  template <typename T>
-  std::shared_ptr<Queue<T>> get_queue(const std::string &name);
+  template<typename T>
+  std::shared_ptr<Queue<T>> get_queue(const std::string& name);
 
   /**
    * @brief Configure the QueueRegistry
    * @param configmap Map relating Queue names to their configurations
    */
-  void configure(const std::map<std::string, QueueConfig> &configmap);
+  void configure(const std::map<std::string, QueueConfig>& configmap);
 
 private:
-  struct QueueEntry {
-    const std::type_info *type;
+  struct QueueEntry
+  {
+    const std::type_info* type;
     std::shared_ptr<NamedObject> instance;
   };
 
   QueueRegistry();
 
-  template <typename T>
-  std::shared_ptr<NamedObject> create_queue(std::string name,
-                                            const QueueConfig &config);
+  template<typename T>
+  std::shared_ptr<NamedObject> create_queue(std::string name, const QueueConfig& config);
 
   std::map<std::string, QueueEntry> queue_registry_;
   std::map<std::string, QueueConfig> queue_configmap_;
 
   bool configured_;
 
-  static QueueRegistry *me_;
+  static QueueRegistry* me_;
 
-  QueueRegistry(const QueueRegistry &) = delete;
-  QueueRegistry &operator=(const QueueRegistry &) = delete;
-  QueueRegistry(QueueRegistry &&) = delete;
-  QueueRegistry &operator=(QueueRegistry &&) = delete;
+  QueueRegistry(const QueueRegistry&) = delete;
+  QueueRegistry& operator=(const QueueRegistry&) = delete;
+  QueueRegistry(QueueRegistry&&) = delete;
+  QueueRegistry& operator=(QueueRegistry&&) = delete;
 };
 
 } // namespace appfwk
@@ -111,12 +113,9 @@ private:
  */
 ERS_DECLARE_ISSUE(appfwk,            // namespace
                   QueueTypeMismatch, // issue class name
-                  "Requested queue \""
-                      << queue_name << "\" of type '" << target_type
-                      << "' already declared as type '" << source_type
-                      << "'", // message
-                  ((std::string)queue_name)((std::string)source_type)(
-                      (std::string)target_type))
+                  "Requested queue \"" << queue_name << "\" of type '" << target_type << "' already declared as type '"
+                                       << source_type << "'", // message
+                  ((std::string)queue_name)((std::string)source_type)((std::string)target_type))
 
 /**
  * @brief QueueKindUnknown ERS Issue

--- a/include/appfwk/StdDeQueue.hpp
+++ b/include/appfwk/StdDeQueue.hpp
@@ -32,44 +32,46 @@ namespace dunedaq::appfwk {
 /**
  * @brief A Queue Implementation that uses a std::deque as its backend
  * @tparam T Data Type to be stored in the std::deque
-*/
-template<class T>
-class StdDeQueue : public Queue<T>
-{
+ */
+template <class T> class StdDeQueue : public Queue<T> {
 public:
   using value_type = T; ///< Type of data stored in the StdDeQueue
-  using duration_type = typename Queue<T>::duration_type; ///< Type used for expressing timeouts
+  using duration_type =
+      typename Queue<T>::duration_type; ///< Type used for expressing timeouts
 
   /**
    * @brief StdDeQueue Constructor
    * @param name Name of this StdDeQueue instance
-  */
-  explicit StdDeQueue(const std::string& name);
+   */
+  explicit StdDeQueue(const std::string &name);
 
   bool can_pop() const noexcept override { return fSize.load() > 0; }
-  bool pop( value_type & val, const duration_type&)
-    override; // Throws std::runtime_error if a timeout occurs
+  bool pop(value_type &val, const duration_type &)
+      override; // Throws std::runtime_error if a timeout occurs
 
   bool can_push() const noexcept override { return fSize.load() < fMaxSize; }
-  void push(value_type&&, const duration_type&)
-    override; // Throws std::runtime_error if a timeout occurs
+  void push(value_type &&, const duration_type &)
+      override; // Throws std::runtime_error if a timeout occurs
 
   // Delete the copy and move operations since various member data instances
   // (e.g., of std::mutex or of std::atomic) aren't copyable or movable
 
-  StdDeQueue(const StdDeQueue&) = delete; ///< StdDeQueue is not copy-constructible
-  StdDeQueue& operator=(const StdDeQueue&) = delete; ///< StdDeQueue is not copy-assignable
-  StdDeQueue(StdDeQueue&&) = delete; ///< StdDeQueue is not move-constructible
-  StdDeQueue& operator=(StdDeQueue&&) = delete; ///< StdDeQueue is not move-assignable
+  StdDeQueue(const StdDeQueue &) =
+      delete; ///< StdDeQueue is not copy-constructible
+  StdDeQueue &
+  operator=(const StdDeQueue &) = delete; ///< StdDeQueue is not copy-assignable
+  StdDeQueue(StdDeQueue &&) = delete; ///< StdDeQueue is not move-constructible
+  StdDeQueue &
+  operator=(StdDeQueue &&) = delete; ///< StdDeQueue is not move-assignable
 
   /**
    * @brief Set the size of the StdDeQueue
    * @param sz Maximum size for the StdDeQueue
-  */
+   */
   void SetSize(size_t sz) { fMaxSize = sz; }
 
 private:
-  void try_lock_for(std::unique_lock<std::mutex>&, const duration_type&);
+  void try_lock_for(std::unique_lock<std::mutex> &, const duration_type &);
 
   size_t fMaxSize;
 

--- a/include/appfwk/StdDeQueue.hpp
+++ b/include/appfwk/StdDeQueue.hpp
@@ -33,36 +33,32 @@ namespace dunedaq::appfwk {
  * @brief A Queue Implementation that uses a std::deque as its backend
  * @tparam T Data Type to be stored in the std::deque
  */
-template <class T> class StdDeQueue : public Queue<T> {
+template<class T>
+class StdDeQueue : public Queue<T>
+{
 public:
-  using value_type = T; ///< Type of data stored in the StdDeQueue
-  using duration_type =
-      typename Queue<T>::duration_type; ///< Type used for expressing timeouts
+  using value_type = T;                                   ///< Type of data stored in the StdDeQueue
+  using duration_type = typename Queue<T>::duration_type; ///< Type used for expressing timeouts
 
   /**
    * @brief StdDeQueue Constructor
    * @param name Name of this StdDeQueue instance
    */
-  explicit StdDeQueue(const std::string &name);
+  explicit StdDeQueue(const std::string& name);
 
   bool can_pop() const noexcept override { return fSize.load() > 0; }
-  bool pop(value_type &val, const duration_type &)
-      override; // Throws std::runtime_error if a timeout occurs
+  bool pop(value_type& val, const duration_type&) override; // Throws std::runtime_error if a timeout occurs
 
   bool can_push() const noexcept override { return fSize.load() < fMaxSize; }
-  void push(value_type &&, const duration_type &)
-      override; // Throws std::runtime_error if a timeout occurs
+  void push(value_type&&, const duration_type&) override; // Throws std::runtime_error if a timeout occurs
 
   // Delete the copy and move operations since various member data instances
   // (e.g., of std::mutex or of std::atomic) aren't copyable or movable
 
-  StdDeQueue(const StdDeQueue &) =
-      delete; ///< StdDeQueue is not copy-constructible
-  StdDeQueue &
-  operator=(const StdDeQueue &) = delete; ///< StdDeQueue is not copy-assignable
-  StdDeQueue(StdDeQueue &&) = delete; ///< StdDeQueue is not move-constructible
-  StdDeQueue &
-  operator=(StdDeQueue &&) = delete; ///< StdDeQueue is not move-assignable
+  StdDeQueue(const StdDeQueue&) = delete;            ///< StdDeQueue is not copy-constructible
+  StdDeQueue& operator=(const StdDeQueue&) = delete; ///< StdDeQueue is not copy-assignable
+  StdDeQueue(StdDeQueue&&) = delete;                 ///< StdDeQueue is not move-constructible
+  StdDeQueue& operator=(StdDeQueue&&) = delete;      ///< StdDeQueue is not move-assignable
 
   /**
    * @brief Set the size of the StdDeQueue
@@ -71,7 +67,7 @@ public:
   void SetSize(size_t sz) { fMaxSize = sz; }
 
 private:
-  void try_lock_for(std::unique_lock<std::mutex> &, const duration_type &);
+  void try_lock_for(std::unique_lock<std::mutex>&, const duration_type&);
 
   size_t fMaxSize;
 

--- a/include/appfwk/detail/FanOutDAQModule.hxx
+++ b/include/appfwk/detail/FanOutDAQModule.hxx
@@ -1,21 +1,14 @@
 
-template<typename ValueType>
+template <typename ValueType>
 dunedaq::appfwk::FanOutDAQModule<ValueType>::FanOutDAQModule(std::string name)
-  : DAQModule(name)
-  , mode_(FanOutMode::NotConfigured)
-  , queueTimeout_(100)
-  , thread_(std::bind(&FanOutDAQModule<ValueType>::do_work, this))
-  , wait_interval_us_(std::numeric_limits<size_t>::max())
-  , inputQueue_(nullptr)
-  , outputQueues_()
-{}
+    : DAQModule(name), mode_(FanOutMode::NotConfigured), queueTimeout_(100),
+      thread_(std::bind(&FanOutDAQModule<ValueType>::do_work, this)),
+      wait_interval_us_(std::numeric_limits<size_t>::max()),
+      inputQueue_(nullptr), outputQueues_() {}
 
-template<typename ValueType>
-void
-dunedaq::appfwk::FanOutDAQModule<ValueType>::execute_command(
-  const std::string& cmd,
-  const std::vector<std::string>& /*args*/)
-{
+template <typename ValueType>
+void dunedaq::appfwk::FanOutDAQModule<ValueType>::execute_command(
+    const std::string &cmd, const std::vector<std::string> & /*args*/) {
   if (cmd == "configure" || cmd == "Configure") {
     do_configure();
   }
@@ -27,10 +20,8 @@ dunedaq::appfwk::FanOutDAQModule<ValueType>::execute_command(
   }
 }
 
-template<typename ValueType>
-std::string
-dunedaq::appfwk::FanOutDAQModule<ValueType>::do_configure()
-{
+template <typename ValueType>
+std::string dunedaq::appfwk::FanOutDAQModule<ValueType>::do_configure() {
   if (configuration_.contains("fanout_mode")) {
     auto modeString = configuration_["fanout_mode"].get<std::string>();
     if (modeString.find("roadcast") != std::string::npos) {
@@ -51,37 +42,31 @@ dunedaq::appfwk::FanOutDAQModule<ValueType>::do_configure()
   wait_interval_us_ = configuration_.value<int>("wait_interval", 1000000);
 
   auto inputName = configuration_["input"].get<std::string>();
-  TLOG(TLVL_DEBUG, "FanOutDAQModule") << get_name() << ": Getting queue with name " << inputName
-                  << " as input";
+  TLOG(TLVL_DEBUG, "FanOutDAQModule")
+      << get_name() << ": Getting queue with name " << inputName << " as input";
   inputQueue_.reset(new DAQSource<ValueType>(inputName));
-  for (auto& output : configuration_["outputs"]) {
+  for (auto &output : configuration_["outputs"]) {
     outputQueues_.emplace_back(
-      new DAQSink<ValueType>(output.get<std::string>()));
+        new DAQSink<ValueType>(output.get<std::string>()));
   }
 
   return "Success";
 }
 
-template<typename ValueType>
-std::string
-dunedaq::appfwk::FanOutDAQModule<ValueType>::do_start()
-{
+template <typename ValueType>
+std::string dunedaq::appfwk::FanOutDAQModule<ValueType>::do_start() {
   thread_.start_working_thread_();
   return "Success";
 }
 
-template<typename ValueType>
-std::string
-dunedaq::appfwk::FanOutDAQModule<ValueType>::do_stop()
-{
+template <typename ValueType>
+std::string dunedaq::appfwk::FanOutDAQModule<ValueType>::do_stop() {
   thread_.stop_working_thread_();
   return "Success";
 }
 
-template<typename ValueType>
-void
-dunedaq::appfwk::FanOutDAQModule<ValueType>::do_work()
-{
+template <typename ValueType>
+void dunedaq::appfwk::FanOutDAQModule<ValueType>::do_work() {
   auto roundRobinNext = outputQueues_.begin();
 
   // unique_ptr needed since there's no guarantee ValueType has a no-argument
@@ -91,38 +76,39 @@ dunedaq::appfwk::FanOutDAQModule<ValueType>::do_work()
   while (thread_.thread_running()) {
     if (inputQueue_->can_pop()) {
 
-      if ( ! inputQueue_->pop( *data_ptr, queueTimeout_) ) {
-	TLOG(TLVL_WARNING) << get_name()
-                           << ": Tried but failed to pop a value from an inputQueue" ; 
-	  continue;
-	}
+      if (!inputQueue_->pop(*data_ptr, queueTimeout_)) {
+        TLOG(TLVL_WARNING)
+            << get_name()
+            << ": Tried but failed to pop a value from an inputQueue";
+        continue;
+      }
 
       if (mode_ == FanOutMode::Broadcast) {
         do_broadcast(*data_ptr);
       } else if (mode_ == FanOutMode::FirstAvailable) {
         auto sent = false;
         while (!sent) {
-          for (auto& o : outputQueues_) {
+          for (auto &o : outputQueues_) {
             if (o->can_push()) {
               auto starttime = std::chrono::steady_clock::now();
               o->push(std::move(*data_ptr), queueTimeout_);
               auto endtime = std::chrono::steady_clock::now();
-	      
+
               if (std::chrono::duration_cast<decltype(queueTimeout_)>(
-                    endtime - starttime) < queueTimeout_) {
+                      endtime - starttime) < queueTimeout_) {
                 sent = true;
                 break;
               } else {
                 TLOG(TLVL_WARNING)
-                  << get_name()
-                  << ": A timeout occurred trying to push data "
-                     "onto an outputqueue; data has been lost";
+                    << get_name()
+                    << ": A timeout occurred trying to push data "
+                       "onto an outputqueue; data has been lost";
               }
             }
           }
           if (!sent) {
             std::this_thread::sleep_for(
-              std::chrono::microseconds(wait_interval_us_));
+                std::chrono::microseconds(wait_interval_us_));
           }
         }
       } else if (mode_ == FanOutMode::RoundRobin) {
@@ -134,7 +120,7 @@ dunedaq::appfwk::FanOutDAQModule<ValueType>::do_work()
             auto endtime = std::chrono::steady_clock::now();
 
             if (std::chrono::duration_cast<decltype(queueTimeout_)>(
-                  endtime - starttime) >= queueTimeout_) {
+                    endtime - starttime) >= queueTimeout_) {
               TLOG(TLVL_WARNING) << get_name()
                                  << ": A timeout occurred trying to push data "
                                     "onto an outputqueue; data has been lost";
@@ -146,7 +132,7 @@ dunedaq::appfwk::FanOutDAQModule<ValueType>::do_work()
             break;
           } else {
             std::this_thread::sleep_for(
-              std::chrono::microseconds(wait_interval_us_));
+                std::chrono::microseconds(wait_interval_us_));
           }
         }
       }

--- a/include/appfwk/detail/QueueRegistry.hxx
+++ b/include/appfwk/detail/QueueRegistry.hxx
@@ -5,34 +5,35 @@
 // Declarations
 namespace dunedaq::appfwk {
 
-  QueueConfig::queue_kind QueueConfig::stoqk( const std::string & name )   {
-    if (name == "StdDeQueue" || name == "std_deque")
-      return queue_kind::kStdDeQueue ;
-    else
-      throw QueueKindUnknown( ERS_HERE, name ) ;
-  }
+QueueConfig::queue_kind QueueConfig::stoqk(const std::string &name) {
+  if (name == "StdDeQueue" || name == "std_deque")
+    return queue_kind::kStdDeQueue;
+  else
+    throw QueueKindUnknown(ERS_HERE, name);
+}
 
-template<typename T>
-std::shared_ptr<Queue<T>> 
-QueueRegistry::get_queue( const std::string & name) {
+template <typename T>
+std::shared_ptr<Queue<T>> QueueRegistry::get_queue(const std::string &name) {
 
   auto itQ = queue_registry_.find(name);
-  if ( itQ != queue_registry_.end() ) {
-      auto queuePtr =  std::dynamic_pointer_cast<Queue<T>>(itQ->second.instance);
+  if (itQ != queue_registry_.end()) {
+    auto queuePtr = std::dynamic_pointer_cast<Queue<T>>(itQ->second.instance);
 
-      if (!queuePtr) {
-        int     status;
-        std::string realname_target = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
-        std::string realname_source = abi::__cxa_demangle(itQ->second.type->name(), 0, 0, &status);
+    if (!queuePtr) {
+      int status;
+      std::string realname_target =
+          abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
+      std::string realname_source =
+          abi::__cxa_demangle(itQ->second.type->name(), 0, 0, &status);
 
-        throw QueueTypeMismatch(ERS_HERE, name, realname_source, realname_target);
-      }
+      throw QueueTypeMismatch(ERS_HERE, name, realname_source, realname_target);
+    }
 
-      return queuePtr;
-  } 
+    return queuePtr;
+  }
 
   auto itP = this->queue_configmap_.find(name);
-  if ( itP != queue_configmap_.end() ) {
+  if (itP != queue_configmap_.end()) {
     QueueEntry entry = {&typeid(T), create_queue<T>(name, itP->second)};
     queue_registry_[name] = entry;
     return std::dynamic_pointer_cast<Queue<T>>(entry.instance);
@@ -42,21 +43,21 @@ QueueRegistry::get_queue( const std::string & name) {
   }
 }
 
-template<typename T>
-std::shared_ptr<NamedObject> QueueRegistry::create_queue(std::string name, const QueueConfig& config) {
+template <typename T>
+std::shared_ptr<NamedObject>
+QueueRegistry::create_queue(std::string name, const QueueConfig &config) {
 
   std::shared_ptr<NamedObject> queue;
-  switch(config.kind) {
-    case QueueConfig::kStdDeQueue :
-      queue = std::make_shared<StdDeQueue<T>>(name);
-      std::dynamic_pointer_cast<StdDeQueue<T>>(queue)->SetSize(config.size);
-      break;
-    default:
-      throw std::runtime_error("Unknown queue kind");
+  switch (config.kind) {
+  case QueueConfig::kStdDeQueue:
+    queue = std::make_shared<StdDeQueue<T>>(name);
+    std::dynamic_pointer_cast<StdDeQueue<T>>(queue)->SetSize(config.size);
+    break;
+  default:
+    throw std::runtime_error("Unknown queue kind");
   }
 
   return queue;
 }
 
 } // namespace dunedaq::appfwk
-

--- a/include/appfwk/detail/QueueRegistry.hxx
+++ b/include/appfwk/detail/QueueRegistry.hxx
@@ -5,15 +5,19 @@
 // Declarations
 namespace dunedaq::appfwk {
 
-QueueConfig::queue_kind QueueConfig::stoqk(const std::string &name) {
+QueueConfig::queue_kind
+QueueConfig::stoqk(const std::string& name)
+{
   if (name == "StdDeQueue" || name == "std_deque")
     return queue_kind::kStdDeQueue;
   else
     throw QueueKindUnknown(ERS_HERE, name);
 }
 
-template <typename T>
-std::shared_ptr<Queue<T>> QueueRegistry::get_queue(const std::string &name) {
+template<typename T>
+std::shared_ptr<Queue<T>>
+QueueRegistry::get_queue(const std::string& name)
+{
 
   auto itQ = queue_registry_.find(name);
   if (itQ != queue_registry_.end()) {
@@ -21,10 +25,8 @@ std::shared_ptr<Queue<T>> QueueRegistry::get_queue(const std::string &name) {
 
     if (!queuePtr) {
       int status;
-      std::string realname_target =
-          abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
-      std::string realname_source =
-          abi::__cxa_demangle(itQ->second.type->name(), 0, 0, &status);
+      std::string realname_target = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
+      std::string realname_source = abi::__cxa_demangle(itQ->second.type->name(), 0, 0, &status);
 
       throw QueueTypeMismatch(ERS_HERE, name, realname_source, realname_target);
     }
@@ -34,7 +36,7 @@ std::shared_ptr<Queue<T>> QueueRegistry::get_queue(const std::string &name) {
 
   auto itP = this->queue_configmap_.find(name);
   if (itP != queue_configmap_.end()) {
-    QueueEntry entry = {&typeid(T), create_queue<T>(name, itP->second)};
+    QueueEntry entry = { &typeid(T), create_queue<T>(name, itP->second) };
     queue_registry_[name] = entry;
     return std::dynamic_pointer_cast<Queue<T>>(entry.instance);
 
@@ -43,18 +45,19 @@ std::shared_ptr<Queue<T>> QueueRegistry::get_queue(const std::string &name) {
   }
 }
 
-template <typename T>
+template<typename T>
 std::shared_ptr<NamedObject>
-QueueRegistry::create_queue(std::string name, const QueueConfig &config) {
+QueueRegistry::create_queue(std::string name, const QueueConfig& config)
+{
 
   std::shared_ptr<NamedObject> queue;
   switch (config.kind) {
-  case QueueConfig::kStdDeQueue:
-    queue = std::make_shared<StdDeQueue<T>>(name);
-    std::dynamic_pointer_cast<StdDeQueue<T>>(queue)->SetSize(config.size);
-    break;
-  default:
-    throw std::runtime_error("Unknown queue kind");
+    case QueueConfig::kStdDeQueue:
+      queue = std::make_shared<StdDeQueue<T>>(name);
+      std::dynamic_pointer_cast<StdDeQueue<T>>(queue)->SetSize(config.size);
+      break;
+    default:
+      throw std::runtime_error("Unknown queue kind");
   }
 
   return queue;

--- a/include/appfwk/detail/StdDeQueue.hxx
+++ b/include/appfwk/detail/StdDeQueue.hxx
@@ -1,24 +1,27 @@
 
 
-template <class T>
-StdDeQueue<T>::StdDeQueue(const std::string &name)
-    : Queue<T>(name), fMaxSize(0), fDeque(), fSize(0) {}
+template<class T>
+StdDeQueue<T>::StdDeQueue(const std::string& name)
+  : Queue<T>(name)
+  , fMaxSize(0)
+  , fDeque()
+  , fSize(0)
+{}
 
-template <class T>
-void StdDeQueue<T>::push(value_type &&object_to_push,
-                         const duration_type &timeout) {
+template<class T>
+void
+StdDeQueue<T>::push(value_type&& object_to_push, const duration_type& timeout)
+{
 
   auto starttime = std::chrono::steady_clock::now();
   std::unique_lock<std::mutex> lk(fMutex, std::defer_lock);
 
   this->try_lock_for(lk, timeout);
 
-  auto time_to_wait_for_space =
-      (starttime + timeout) - std::chrono::steady_clock::now();
+  auto time_to_wait_for_space = (starttime + timeout) - std::chrono::steady_clock::now();
 
   if (time_to_wait_for_space.count() > 0) {
-    fNoLongerFull.wait_for(lk, time_to_wait_for_space,
-                           [&]() { return this->can_push(); });
+    fNoLongerFull.wait_for(lk, time_to_wait_for_space, [&]() { return this->can_push(); });
   }
 
   if (this->can_push()) {
@@ -27,29 +30,27 @@ void StdDeQueue<T>::push(value_type &&object_to_push,
     fNoLongerEmpty.notify_one();
   } else {
     std::stringstream errmsg;
-    errmsg << "In StdDeQueue::push: unable to push since queue is full ("
-           << fSize.load() << " elements) (timeout period was "
-           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
-                  .count()
-           << " milliseconds)";
+    errmsg << "In StdDeQueue::push: unable to push since queue is full (" << fSize.load()
+           << " elements) (timeout period was "
+           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << " milliseconds)";
     throw std::runtime_error(errmsg.str());
   }
 }
 
-template <class T>
-bool StdDeQueue<T>::pop(T &val, const duration_type &timeout) {
+template<class T>
+bool
+StdDeQueue<T>::pop(T& val, const duration_type& timeout)
+{
 
   auto starttime = std::chrono::steady_clock::now();
   std::unique_lock<std::mutex> lk(fMutex, std::defer_lock);
 
   this->try_lock_for(lk, timeout);
 
-  auto time_to_wait_for_data =
-      (starttime + timeout) - std::chrono::steady_clock::now();
+  auto time_to_wait_for_data = (starttime + timeout) - std::chrono::steady_clock::now();
 
   if (time_to_wait_for_data.count() > 0) {
-    fNoLongerEmpty.wait_for(lk, time_to_wait_for_data,
-                            [&]() { return this->can_pop(); });
+    fNoLongerEmpty.wait_for(lk, time_to_wait_for_data, [&]() { return this->can_pop(); });
   }
 
   if (this->can_pop()) {
@@ -62,9 +63,7 @@ bool StdDeQueue<T>::pop(T &val, const duration_type &timeout) {
     std::stringstream errmsg;
     errmsg << "In StdDeQueue::pop_wait_for: unable to pop since queue is "
               "empty (timeout period was "
-           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
-                  .count()
-           << " milliseconds)";
+           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << " milliseconds)";
     return false;
   }
 }
@@ -74,9 +73,10 @@ bool StdDeQueue<T>::pop(T &val, const duration_type &timeout) {
 // std::condition_variable::wait_for functions used in this class's push
 // and pop operations require an std::mutex
 
-template <class T>
-void StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex> &lk,
-                                 const duration_type &timeout) {
+template<class T>
+void
+StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex>& lk, const duration_type& timeout)
+{
   assert(!lk.owns_lock());
 
   auto starttime = std::chrono::steady_clock::now();
@@ -85,8 +85,7 @@ void StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex> &lk,
   if (!lk.owns_lock() && timeout.count() > 0) {
 
     int approximate_number_of_retries = 5;
-    duration_type pause_between_tries =
-        duration_type(timeout.count() / approximate_number_of_retries);
+    duration_type pause_between_tries = duration_type(timeout.count() / approximate_number_of_retries);
 
     while (std::chrono::steady_clock::now() < starttime + timeout) {
       std::this_thread::sleep_for(pause_between_tries);
@@ -101,9 +100,7 @@ void StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex> &lk,
     std::ostringstream errmsg;
     errmsg << "Unable to lock the StdDeQueue's mutex "
               "within the timeout period of "
-           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
-                  .count()
-           << " milliseconds";
+           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << " milliseconds";
     throw std::runtime_error(errmsg.str());
   }
 }

--- a/include/appfwk/detail/StdDeQueue.hxx
+++ b/include/appfwk/detail/StdDeQueue.hxx
@@ -1,17 +1,12 @@
 
 
-template<class T>
-StdDeQueue<T>::StdDeQueue(const std::string& name)
-  : Queue<T>(name)
-  , fMaxSize(0)
-  , fDeque()
-  , fSize(0)
-{}
+template <class T>
+StdDeQueue<T>::StdDeQueue(const std::string &name)
+    : Queue<T>(name), fMaxSize(0), fDeque(), fSize(0) {}
 
-template<class T>
-void
-StdDeQueue<T>::push(value_type&& object_to_push, const duration_type& timeout)
-{
+template <class T>
+void StdDeQueue<T>::push(value_type &&object_to_push,
+                         const duration_type &timeout) {
 
   auto starttime = std::chrono::steady_clock::now();
   std::unique_lock<std::mutex> lk(fMutex, std::defer_lock);
@@ -19,11 +14,11 @@ StdDeQueue<T>::push(value_type&& object_to_push, const duration_type& timeout)
   this->try_lock_for(lk, timeout);
 
   auto time_to_wait_for_space =
-    (starttime + timeout) - std::chrono::steady_clock::now();
+      (starttime + timeout) - std::chrono::steady_clock::now();
 
   if (time_to_wait_for_space.count() > 0) {
-    fNoLongerFull.wait_for(
-      lk, time_to_wait_for_space, [&]() { return this->can_push(); });
+    fNoLongerFull.wait_for(lk, time_to_wait_for_space,
+                           [&]() { return this->can_push(); });
   }
 
   if (this->can_push()) {
@@ -32,19 +27,17 @@ StdDeQueue<T>::push(value_type&& object_to_push, const duration_type& timeout)
     fNoLongerEmpty.notify_one();
   } else {
     std::stringstream errmsg;
-    errmsg
-      << "In StdDeQueue::push: unable to push since queue is full ("
-      << fSize.load() << " elements) (timeout period was "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count()
-      << " milliseconds)";
+    errmsg << "In StdDeQueue::push: unable to push since queue is full ("
+           << fSize.load() << " elements) (timeout period was "
+           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
+                  .count()
+           << " milliseconds)";
     throw std::runtime_error(errmsg.str());
   }
 }
 
-template<class T>
-bool 
-StdDeQueue<T>::pop(T & val, const duration_type& timeout)
-{
+template <class T>
+bool StdDeQueue<T>::pop(T &val, const duration_type &timeout) {
 
   auto starttime = std::chrono::steady_clock::now();
   std::unique_lock<std::mutex> lk(fMutex, std::defer_lock);
@@ -52,27 +45,27 @@ StdDeQueue<T>::pop(T & val, const duration_type& timeout)
   this->try_lock_for(lk, timeout);
 
   auto time_to_wait_for_data =
-    (starttime + timeout) - std::chrono::steady_clock::now();
+      (starttime + timeout) - std::chrono::steady_clock::now();
 
   if (time_to_wait_for_data.count() > 0) {
-    fNoLongerEmpty.wait_for(
-      lk, time_to_wait_for_data, [&]() { return this->can_pop(); });
+    fNoLongerEmpty.wait_for(lk, time_to_wait_for_data,
+                            [&]() { return this->can_pop(); });
   }
 
   if (this->can_pop()) {
-    val = std::move(fDeque.front()) ;
+    val = std::move(fDeque.front());
     fDeque.pop_front();
     fSize--;
     fNoLongerFull.notify_one();
-    return true ;
+    return true;
   } else {
     std::stringstream errmsg;
-    errmsg
-      << "In StdDeQueue::pop_wait_for: unable to pop since queue is "
-         "empty (timeout period was "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count()
-      << " milliseconds)";
-    return false ; 
+    errmsg << "In StdDeQueue::pop_wait_for: unable to pop since queue is "
+              "empty (timeout period was "
+           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
+                  .count()
+           << " milliseconds)";
+    return false;
   }
 }
 
@@ -81,11 +74,9 @@ StdDeQueue<T>::pop(T & val, const duration_type& timeout)
 // std::condition_variable::wait_for functions used in this class's push
 // and pop operations require an std::mutex
 
-template<class T>
-void
-StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex>& lk,
-                            const duration_type& timeout)
-{
+template <class T>
+void StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex> &lk,
+                                 const duration_type &timeout) {
   assert(!lk.owns_lock());
 
   auto starttime = std::chrono::steady_clock::now();
@@ -95,7 +86,7 @@ StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex>& lk,
 
     int approximate_number_of_retries = 5;
     duration_type pause_between_tries =
-      duration_type(timeout.count() / approximate_number_of_retries);
+        duration_type(timeout.count() / approximate_number_of_retries);
 
     while (std::chrono::steady_clock::now() < starttime + timeout) {
       std::this_thread::sleep_for(pause_between_tries);
@@ -108,11 +99,11 @@ StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex>& lk,
 
   if (!lk.owns_lock()) {
     std::ostringstream errmsg;
-    errmsg
-      << "Unable to lock the StdDeQueue's mutex "
-         "within the timeout period of "
-      << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count()
-      << " milliseconds";
+    errmsg << "Unable to lock the StdDeQueue's mutex "
+              "within the timeout period of "
+           << std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
+                  .count()
+           << " milliseconds";
     throw std::runtime_error(errmsg.str());
   }
 }

--- a/src/DAQProcess.cpp
+++ b/src/DAQProcess.cpp
@@ -25,26 +25,21 @@
 namespace dunedaq::appfwk {
 std::unique_ptr<CommandFacility> CommandFacility::handle_ = nullptr;
 
-DAQProcess::DAQProcess(CommandLineInterpreter args)
-{
+DAQProcess::DAQProcess(CommandLineInterpreter args) {
   CommandFacility::setHandle(
-    makeCommandFacility(args.commandFacilityPluginName));
+      makeCommandFacility(args.commandFacilityPluginName));
   Logger::setup(args.otherOptions);
   CommandFacility::handle().setup(args.otherOptions);
 }
 
-void
-DAQProcess::register_modules( GraphConstructor & ml)
-{
+void DAQProcess::register_modules(GraphConstructor &ml) {
   ml.ConstructGraph(daqModuleMap_, commandOrderMap_);
 }
 
-void
-DAQProcess::execute_command(std::string const& cmd,
-                            std::vector<std::string> const& args)
-{
+void DAQProcess::execute_command(std::string const &cmd,
+                                 std::vector<std::string> const &args) {
   std::unordered_set<std::string> daq_module_list;
-  for (auto const& dm : daqModuleMap_) {
+  for (auto const &dm : daqModuleMap_) {
     daq_module_list.insert(dm.first);
   }
 
@@ -52,7 +47,7 @@ DAQProcess::execute_command(std::string const& cmd,
                    << " for DAQModules defined in the CommandOrderMap";
 
   if (commandOrderMap_.count(cmd)) {
-    for (auto& moduleName : commandOrderMap_[cmd]) {
+    for (auto &moduleName : commandOrderMap_[cmd]) {
       if (daqModuleMap_.count(moduleName)) {
 
         call_command_on_module(*daqModuleMap_[moduleName], cmd, args);
@@ -67,32 +62,23 @@ DAQProcess::execute_command(std::string const& cmd,
 
   TLOG(TLVL_DEBUG) << "Executing Command " << cmd
                    << " for all remaining DAQModules";
-  for (auto const& moduleName : daq_module_list) {
+  for (auto const &moduleName : daq_module_list) {
 
     call_command_on_module(*daqModuleMap_[moduleName], cmd, args);
   }
 }
 
-int
-DAQProcess::listen()
-{
-  return CommandFacility::handle().listen(this);
-}
+int DAQProcess::listen() { return CommandFacility::handle().listen(this); }
 
-void
-DAQProcess::call_command_on_module(DAQModule& mod,
-                                   const std::string& cmd,
-                                   std::vector<std::string> const& args)
-{
+void DAQProcess::call_command_on_module(DAQModule &mod, const std::string &cmd,
+                                        std::vector<std::string> const &args) {
 
   try {
     mod.execute_command(cmd, args);
-  } 
-  catch (GeneralDAQModuleIssue& ex) {
+  } catch (GeneralDAQModuleIssue &ex) {
     ers::error(ex);
-  }
-  catch (...) {  // NOLINT
-    ers::error( ModuleThrowUnknown( ERS_HERE, mod.get_name(), cmd ) ) ;
+  } catch (...) { // NOLINT
+    ers::error(ModuleThrowUnknown(ERS_HERE, mod.get_name(), cmd));
   }
 }
 } // namespace dunedaq::appfwk

--- a/src/DAQProcess.cpp
+++ b/src/DAQProcess.cpp
@@ -25,29 +25,31 @@
 namespace dunedaq::appfwk {
 std::unique_ptr<CommandFacility> CommandFacility::handle_ = nullptr;
 
-DAQProcess::DAQProcess(CommandLineInterpreter args) {
-  CommandFacility::setHandle(
-      makeCommandFacility(args.commandFacilityPluginName));
+DAQProcess::DAQProcess(CommandLineInterpreter args)
+{
+  CommandFacility::setHandle(makeCommandFacility(args.commandFacilityPluginName));
   Logger::setup(args.otherOptions);
   CommandFacility::handle().setup(args.otherOptions);
 }
 
-void DAQProcess::register_modules(GraphConstructor &ml) {
+void
+DAQProcess::register_modules(GraphConstructor& ml)
+{
   ml.ConstructGraph(daqModuleMap_, commandOrderMap_);
 }
 
-void DAQProcess::execute_command(std::string const &cmd,
-                                 std::vector<std::string> const &args) {
+void
+DAQProcess::execute_command(std::string const& cmd, std::vector<std::string> const& args)
+{
   std::unordered_set<std::string> daq_module_list;
-  for (auto const &dm : daqModuleMap_) {
+  for (auto const& dm : daqModuleMap_) {
     daq_module_list.insert(dm.first);
   }
 
-  TLOG(TLVL_DEBUG) << "Executing Command " << cmd
-                   << " for DAQModules defined in the CommandOrderMap";
+  TLOG(TLVL_DEBUG) << "Executing Command " << cmd << " for DAQModules defined in the CommandOrderMap";
 
   if (commandOrderMap_.count(cmd)) {
-    for (auto &moduleName : commandOrderMap_[cmd]) {
+    for (auto& moduleName : commandOrderMap_[cmd]) {
       if (daqModuleMap_.count(moduleName)) {
 
         call_command_on_module(*daqModuleMap_[moduleName], cmd, args);
@@ -60,22 +62,26 @@ void DAQProcess::execute_command(std::string const &cmd,
     ers::warning(CommandOrderNotSpecified(ERS_HERE, cmd));
   }
 
-  TLOG(TLVL_DEBUG) << "Executing Command " << cmd
-                   << " for all remaining DAQModules";
-  for (auto const &moduleName : daq_module_list) {
+  TLOG(TLVL_DEBUG) << "Executing Command " << cmd << " for all remaining DAQModules";
+  for (auto const& moduleName : daq_module_list) {
 
     call_command_on_module(*daqModuleMap_[moduleName], cmd, args);
   }
 }
 
-int DAQProcess::listen() { return CommandFacility::handle().listen(this); }
+int
+DAQProcess::listen()
+{
+  return CommandFacility::handle().listen(this);
+}
 
-void DAQProcess::call_command_on_module(DAQModule &mod, const std::string &cmd,
-                                        std::vector<std::string> const &args) {
+void
+DAQProcess::call_command_on_module(DAQModule& mod, const std::string& cmd, std::vector<std::string> const& args)
+{
 
   try {
     mod.execute_command(cmd, args);
-  } catch (GeneralDAQModuleIssue &ex) {
+  } catch (GeneralDAQModuleIssue& ex) {
     ers::error(ex);
   } catch (...) { // NOLINT
     ers::error(ModuleThrowUnknown(ERS_HERE, mod.get_name(), cmd));

--- a/src/QueryResponseCommandFacility.cpp
+++ b/src/QueryResponseCommandFacility.cpp
@@ -14,7 +14,9 @@
 
 namespace dunedaq::appfwk {
 
-int QueryResponseCommandFacility::listen(DAQProcess *process) {
+int
+QueryResponseCommandFacility::listen(DAQProcess* process)
+{
   try {
     bool keepGoing = true;
     while (keepGoing) {

--- a/src/QueryResponseCommandFacility.cpp
+++ b/src/QueryResponseCommandFacility.cpp
@@ -1,5 +1,6 @@
 /**
- * @file QueryResponseCommandFacility.cpp QueryResponseCommandFacility class Implementation
+ * @file QueryResponseCommandFacility.cpp QueryResponseCommandFacility class
+ * Implementation
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -13,9 +14,7 @@
 
 namespace dunedaq::appfwk {
 
-int
-QueryResponseCommandFacility::listen(DAQProcess* process)
-{
+int QueryResponseCommandFacility::listen(DAQProcess *process) {
   try {
     bool keepGoing = true;
     while (keepGoing) {
@@ -30,7 +29,7 @@ QueryResponseCommandFacility::listen(DAQProcess* process)
         process->execute_command(comm);
       }
     }
-  } catch (...)  // NOLINT
+  } catch (...) // NOLINT
   {
     return -1;
   }

--- a/src/QueryResponseCommandFacility.hpp
+++ b/src/QueryResponseCommandFacility.hpp
@@ -21,17 +21,17 @@ namespace dunedaq::appfwk {
  * @brief QueryResponseCommandFacility is a CommandFacility plugin for running a
  * DAQ Application in an interactive session
  */
-class QueryResponseCommandFacility : public CommandFacility
-{
+class QueryResponseCommandFacility : public CommandFacility {
 public:
   /**
    * @brief Listen for commands from stdin, and pass them to the attached
    * DAQProcess
    * @param theProcess Pointer to the DAQProcess instance which will distribute
    * received commands
-   * @return Status code. 0 if terminated by quit command, -1 if an exception occurs
+   * @return Status code. 0 if terminated by quit command, -1 if an exception
+   * occurs
    */
-  int listen(DAQProcess* theProcess) override;
+  int listen(DAQProcess *theProcess) override;
   virtual ~QueryResponseCommandFacility();
 };
 } // namespace dunedaq::appfwk

--- a/src/QueryResponseCommandFacility.hpp
+++ b/src/QueryResponseCommandFacility.hpp
@@ -21,7 +21,8 @@ namespace dunedaq::appfwk {
  * @brief QueryResponseCommandFacility is a CommandFacility plugin for running a
  * DAQ Application in an interactive session
  */
-class QueryResponseCommandFacility : public CommandFacility {
+class QueryResponseCommandFacility : public CommandFacility
+{
 public:
   /**
    * @brief Listen for commands from stdin, and pass them to the attached
@@ -31,7 +32,7 @@ public:
    * @return Status code. 0 if terminated by quit command, -1 if an exception
    * occurs
    */
-  int listen(DAQProcess *theProcess) override;
+  int listen(DAQProcess* theProcess) override;
   virtual ~QueryResponseCommandFacility();
 };
 } // namespace dunedaq::appfwk

--- a/src/QueueRegistry.cpp
+++ b/src/QueueRegistry.cpp
@@ -12,21 +12,26 @@
 
 namespace dunedaq::appfwk {
 
-QueueRegistry *QueueRegistry::me_ = nullptr;
+QueueRegistry* QueueRegistry::me_ = nullptr;
 
-QueueRegistry::QueueRegistry() : configured_(false) {}
+QueueRegistry::QueueRegistry()
+  : configured_(false)
+{}
 
 QueueRegistry::~QueueRegistry() {}
 
-QueueRegistry &QueueRegistry::get() {
+QueueRegistry&
+QueueRegistry::get()
+{
   if (!me_) {
     me_ = new QueueRegistry();
   }
   return *me_;
 }
 
-void QueueRegistry::configure(
-    const std::map<std::string, QueueConfig> &configmap) {
+void
+QueueRegistry::configure(const std::map<std::string, QueueConfig>& configmap)
+{
   if (configured_) {
     throw std::runtime_error("QueueRegistry already configured");
   }

--- a/src/QueueRegistry.cpp
+++ b/src/QueueRegistry.cpp
@@ -1,5 +1,5 @@
 /**
- * @file QueueRegistry.cpp 
+ * @file QueueRegistry.cpp
  *
  * The QueueRegistry class implementation
  *
@@ -12,26 +12,21 @@
 
 namespace dunedaq::appfwk {
 
-QueueRegistry* QueueRegistry::me_ = nullptr;
+QueueRegistry *QueueRegistry::me_ = nullptr;
 
-QueueRegistry::QueueRegistry()
-  : configured_(false)
-{}
+QueueRegistry::QueueRegistry() : configured_(false) {}
 
 QueueRegistry::~QueueRegistry() {}
 
-QueueRegistry & 
-QueueRegistry::get()
-{
+QueueRegistry &QueueRegistry::get() {
   if (!me_) {
     me_ = new QueueRegistry();
   }
   return *me_;
 }
 
-void
-QueueRegistry::configure(const std::map<std::string, QueueConfig>& configmap)
-{
+void QueueRegistry::configure(
+    const std::map<std::string, QueueConfig> &configmap) {
   if (configured_) {
     throw std::runtime_error("QueueRegistry already configured");
   }

--- a/test/DebugLoggingDAQModule.cpp
+++ b/test/DebugLoggingDAQModule.cpp
@@ -15,11 +15,11 @@
 #include <iostream>
 
 namespace dunedaq::appfwk {
-void DebugLoggingDAQModule::execute_command(
-    const std::string &cmd, const std::vector<std::string> &args) {
-  TLOG(TLVL_INFO) << get_name() << ": Executing command: " << cmd << " with "
-                  << args.size() << " args";
-  for (auto &a : args) {
+void
+DebugLoggingDAQModule::execute_command(const std::string& cmd, const std::vector<std::string>& args)
+{
+  TLOG(TLVL_INFO) << get_name() << ": Executing command: " << cmd << " with " << args.size() << " args";
+  for (auto& a : args) {
     TLOG(TLVL_INFO) << a;
   }
   return;

--- a/test/DebugLoggingDAQModule.cpp
+++ b/test/DebugLoggingDAQModule.cpp
@@ -15,13 +15,11 @@
 #include <iostream>
 
 namespace dunedaq::appfwk {
-void
-DebugLoggingDAQModule::execute_command(const std::string& cmd,
-                                       const std::vector<std::string>& args)
-{
+void DebugLoggingDAQModule::execute_command(
+    const std::string &cmd, const std::vector<std::string> &args) {
   TLOG(TLVL_INFO) << get_name() << ": Executing command: " << cmd << " with "
                   << args.size() << " args";
-  for (auto& a : args) {
+  for (auto &a : args) {
     TLOG(TLVL_INFO) << a;
   }
   return;

--- a/test/DebugLoggingDAQModule.hpp
+++ b/test/DebugLoggingDAQModule.hpp
@@ -22,24 +22,21 @@ namespace dunedaq::appfwk {
  * @brief DebugLoggingDAQModule logs that it has received a command from
  * DAQProcess
  */
-class DebugLoggingDAQModule : public DAQModule
-{
+class DebugLoggingDAQModule : public DAQModule {
 public:
   /**
    * @brief DebugLoggingDAQModule Constructor
    * @param name Instance name for this DebugLoggingDAQModule
-  */
-  explicit DebugLoggingDAQModule( const std::string & name)
-    : DAQModule(name)
-  {}
+   */
+  explicit DebugLoggingDAQModule(const std::string &name) : DAQModule(name) {}
 
   /**
    * @brief Execute a command from DAQProcess
    * @param cmd Command from DAQProcess
    * @param args Arguments for the command from DAQProcess
    */
-  void execute_command(const std::string& cmd,
-                       const std::vector<std::string>& args = {}) override;
+  void execute_command(const std::string &cmd,
+                       const std::vector<std::string> &args = {}) override;
 };
 } // namespace dunedaq::appfwk
 

--- a/test/DebugLoggingDAQModule.hpp
+++ b/test/DebugLoggingDAQModule.hpp
@@ -22,21 +22,23 @@ namespace dunedaq::appfwk {
  * @brief DebugLoggingDAQModule logs that it has received a command from
  * DAQProcess
  */
-class DebugLoggingDAQModule : public DAQModule {
+class DebugLoggingDAQModule : public DAQModule
+{
 public:
   /**
    * @brief DebugLoggingDAQModule Constructor
    * @param name Instance name for this DebugLoggingDAQModule
    */
-  explicit DebugLoggingDAQModule(const std::string &name) : DAQModule(name) {}
+  explicit DebugLoggingDAQModule(const std::string& name)
+    : DAQModule(name)
+  {}
 
   /**
    * @brief Execute a command from DAQProcess
    * @param cmd Command from DAQProcess
    * @param args Arguments for the command from DAQProcess
    */
-  void execute_command(const std::string &cmd,
-                       const std::vector<std::string> &args = {}) override;
+  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
 };
 } // namespace dunedaq::appfwk
 

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -1,5 +1,6 @@
 /**
- * @file FakeDataConsumerDAQModule.cxx FakeDataConsumerDAQModule class implementation
+ * @file FakeDataConsumerDAQModule.cxx FakeDataConsumerDAQModule class
+ * implementation
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -19,18 +20,13 @@
 #include <thread>
 
 dunedaq::appfwk::FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(
-  const std::string & name)
-  : DAQModule(name)
-  , queueTimeout_(100)
-  , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this))
-  , inputQueue_(nullptr)
-{}
+    const std::string &name)
+    : DAQModule(name), queueTimeout_(100),
+      thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this)),
+      inputQueue_(nullptr) {}
 
-void
-dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(
-  const std::string& cmd,
-  const std::vector<std::string>& args)
-{
+void dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(
+    const std::string &cmd, const std::vector<std::string> &args) {
   if (cmd == "configure" || cmd == "Configure") {
     do_configure();
   } else if (cmd == "start" || cmd == "Start") {
@@ -42,11 +38,9 @@ dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(
   }
 }
 
-std::string
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure()
-{
+std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure() {
   inputQueue_.reset(new DAQSource<std::vector<int>>(
-    configuration_["input"].get<std::string>()));
+      configuration_["input"].get<std::string>()));
 
   nIntsPerVector_ = configuration_.value<int>("nIntsPerVector", 10);
   starting_int_ = configuration_.value<int>("starting_int", -4);
@@ -55,16 +49,12 @@ dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure()
   return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_start()
-{
+std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_start() {
   thread_.start_working_thread_();
   return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop()
-{
+std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop() {
   thread_.stop_working_thread_();
   return "Success";
 }
@@ -74,13 +64,11 @@ dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop()
  * @param t TraceStreamer Instance
  * @param ints Vector to format
  * @return TraceStreamer Instance
-*/
-TraceStreamer&
-operator<<(TraceStreamer& t, std::vector<int> ints)
-{
+ */
+TraceStreamer &operator<<(TraceStreamer &t, std::vector<int> ints) {
   t << "{";
   bool first = true;
-  for (auto& i : ints) {
+  for (auto &i : ints) {
     if (!first)
       t << ", ";
     first = false;
@@ -89,9 +77,7 @@ operator<<(TraceStreamer& t, std::vector<int> ints)
   return t << "}";
 }
 
-void
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_work()
-{
+void dunedaq::appfwk::FakeDataConsumerDAQModule::do_work() {
   int current_int = starting_int_;
   int counter = 0;
   int fail_count = 0;
@@ -103,28 +89,29 @@ dunedaq::appfwk::FakeDataConsumerDAQModule::do_work()
       TLOG(TLVL_DEBUG) << get_name()
                        << ": Going to receive data from inputQueue";
 
-      if ( ! inputQueue_->pop(vec, queueTimeout_) ) {
-        TLOG(TLVL_WARNING) << get_name()
-                           << ": Tried but failed to pop a value from an inputQueue" ;
+      if (!inputQueue_->pop(vec, queueTimeout_)) {
+        TLOG(TLVL_WARNING)
+            << get_name()
+            << ": Tried but failed to pop a value from an inputQueue";
         continue;
       }
-      
+
       TLOG(TLVL_DEBUG) << get_name() << ": Received vector of size "
                        << vec.size();
 
       bool failed = false;
-      
+
       TLOG(TLVL_DEBUG) << get_name() << ": Starting processing loop";
       TLOG(TLVL_INFO) << get_name() << ": Received vector " << counter << ": "
                       << vec;
       size_t ii = 0;
-      for (auto& point : vec) {
+      for (auto &point : vec) {
         if (point != current_int) {
           if (ii != 0) {
             TLOG(TLVL_WARNING)
-              << get_name() << ": Error in received vector " << counter
-              << ", position " << ii << ": Expected " << current_int
-              << ", received " << point;
+                << get_name() << ": Error in received vector " << counter
+                << ", position " << ii << ": Expected " << current_int
+                << ", received " << point;
             failed = true;
           } else {
             TLOG(TLVL_INFO) << get_name() << ": Jump detected!";

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -19,14 +19,17 @@
 #include <functional>
 #include <thread>
 
-dunedaq::appfwk::FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(
-    const std::string &name)
-    : DAQModule(name), queueTimeout_(100),
-      thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this)),
-      inputQueue_(nullptr) {}
+dunedaq::appfwk::FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(const std::string& name)
+  : DAQModule(name)
+  , queueTimeout_(100)
+  , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this))
+  , inputQueue_(nullptr)
+{}
 
-void dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(
-    const std::string &cmd, const std::vector<std::string> &args) {
+void
+dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(const std::string& cmd,
+                                                            const std::vector<std::string>& args)
+{
   if (cmd == "configure" || cmd == "Configure") {
     do_configure();
   } else if (cmd == "start" || cmd == "Start") {
@@ -38,9 +41,10 @@ void dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(
   }
 }
 
-std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure() {
-  inputQueue_.reset(new DAQSource<std::vector<int>>(
-      configuration_["input"].get<std::string>()));
+std::string
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure()
+{
+  inputQueue_.reset(new DAQSource<std::vector<int>>(configuration_["input"].get<std::string>()));
 
   nIntsPerVector_ = configuration_.value<int>("nIntsPerVector", 10);
   starting_int_ = configuration_.value<int>("starting_int", -4);
@@ -49,12 +53,16 @@ std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure() {
   return "Success";
 }
 
-std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_start() {
+std::string
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_start()
+{
   thread_.start_working_thread_();
   return "Success";
 }
 
-std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop() {
+std::string
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop()
+{
   thread_.stop_working_thread_();
   return "Success";
 }
@@ -65,10 +73,12 @@ std::string dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop() {
  * @param ints Vector to format
  * @return TraceStreamer Instance
  */
-TraceStreamer &operator<<(TraceStreamer &t, std::vector<int> ints) {
+TraceStreamer&
+operator<<(TraceStreamer& t, std::vector<int> ints)
+{
   t << "{";
   bool first = true;
-  for (auto &i : ints) {
+  for (auto& i : ints) {
     if (!first)
       t << ", ";
     first = false;
@@ -77,7 +87,9 @@ TraceStreamer &operator<<(TraceStreamer &t, std::vector<int> ints) {
   return t << "}";
 }
 
-void dunedaq::appfwk::FakeDataConsumerDAQModule::do_work() {
+void
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_work()
+{
   int current_int = starting_int_;
   int counter = 0;
   int fail_count = 0;
@@ -86,32 +98,25 @@ void dunedaq::appfwk::FakeDataConsumerDAQModule::do_work() {
   while (thread_.thread_running()) {
     if (inputQueue_->can_pop()) {
 
-      TLOG(TLVL_DEBUG) << get_name()
-                       << ": Going to receive data from inputQueue";
+      TLOG(TLVL_DEBUG) << get_name() << ": Going to receive data from inputQueue";
 
       if (!inputQueue_->pop(vec, queueTimeout_)) {
-        TLOG(TLVL_WARNING)
-            << get_name()
-            << ": Tried but failed to pop a value from an inputQueue";
+        TLOG(TLVL_WARNING) << get_name() << ": Tried but failed to pop a value from an inputQueue";
         continue;
       }
 
-      TLOG(TLVL_DEBUG) << get_name() << ": Received vector of size "
-                       << vec.size();
+      TLOG(TLVL_DEBUG) << get_name() << ": Received vector of size " << vec.size();
 
       bool failed = false;
 
       TLOG(TLVL_DEBUG) << get_name() << ": Starting processing loop";
-      TLOG(TLVL_INFO) << get_name() << ": Received vector " << counter << ": "
-                      << vec;
+      TLOG(TLVL_INFO) << get_name() << ": Received vector " << counter << ": " << vec;
       size_t ii = 0;
-      for (auto &point : vec) {
+      for (auto& point : vec) {
         if (point != current_int) {
           if (ii != 0) {
-            TLOG(TLVL_WARNING)
-                << get_name() << ": Error in received vector " << counter
-                << ", position " << ii << ": Expected " << current_int
-                << ", received " << point;
+            TLOG(TLVL_WARNING) << get_name() << ": Error in received vector " << counter << ", position " << ii
+                               << ": Expected " << current_int << ", received " << point;
             failed = true;
           } else {
             TLOG(TLVL_INFO) << get_name() << ": Jump detected!";
@@ -123,8 +128,7 @@ void dunedaq::appfwk::FakeDataConsumerDAQModule::do_work() {
           current_int = starting_int_;
         ++ii;
       }
-      TLOG(TLVL_DEBUG) << get_name()
-                       << ": Done with processing loop, failed=" << failed;
+      TLOG(TLVL_DEBUG) << get_name() << ": Done with processing loop, failed=" << failed;
       if (failed)
         fail_count++;
 
@@ -134,8 +138,7 @@ void dunedaq::appfwk::FakeDataConsumerDAQModule::do_work() {
     }
   }
 
-  TLOG(TLVL_INFO) << get_name() << ": Processed " << counter << " vectors with "
-                  << fail_count << " failures.";
+  TLOG(TLVL_INFO) << get_name() << ": Processed " << counter << " vectors with " << fail_count << " failures.";
 }
 
 DEFINE_DUNE_DAQ_MODULE(dunedaq::appfwk::FakeDataConsumerDAQModule)

--- a/test/FakeDataConsumerDAQModule.hpp
+++ b/test/FakeDataConsumerDAQModule.hpp
@@ -26,23 +26,25 @@ namespace dunedaq::appfwk {
  * @brief FakeDataConsumerDAQModule creates vectors of ints and sends them
  * downstream
  */
-class FakeDataConsumerDAQModule : public DAQModule
-{
+class FakeDataConsumerDAQModule : public DAQModule {
 public:
   /**
    * @brief FakeDataConsumerDAQModule Constructor
    * @param name Instance name for this FakeDataConsumerDAQModule instance
    */
-  explicit FakeDataConsumerDAQModule(const std::string & name);
+  explicit FakeDataConsumerDAQModule(const std::string &name);
 
-  void execute_command(const std::string& cmd,
-                       const std::vector<std::string>& args = {}) override;
+  void execute_command(const std::string &cmd,
+                       const std::vector<std::string> &args = {}) override;
 
-  FakeDataConsumerDAQModule(const FakeDataConsumerDAQModule&) = delete; ///< FakeDataConsumerDAQModule is not copy-constructible
-  FakeDataConsumerDAQModule& operator=(const FakeDataConsumerDAQModule&) =
-    delete;///< FakeDataConsumerDAQModule is not copy-assignable
-  FakeDataConsumerDAQModule(FakeDataConsumerDAQModule&&) = delete; ///< FakeDataConsumerDAQModule is not move-constructible
-  FakeDataConsumerDAQModule& operator=(FakeDataConsumerDAQModule&&) = delete; ///< FakeDataConsumerDAQModule is not move-assignable
+  FakeDataConsumerDAQModule(const FakeDataConsumerDAQModule &) =
+      delete; ///< FakeDataConsumerDAQModule is not copy-constructible
+  FakeDataConsumerDAQModule &operator=(const FakeDataConsumerDAQModule &) =
+      delete; ///< FakeDataConsumerDAQModule is not copy-assignable
+  FakeDataConsumerDAQModule(FakeDataConsumerDAQModule &&) =
+      delete; ///< FakeDataConsumerDAQModule is not move-constructible
+  FakeDataConsumerDAQModule &operator=(FakeDataConsumerDAQModule &&) =
+      delete; ///< FakeDataConsumerDAQModule is not move-assignable
 
 private:
   // Commands

--- a/test/FakeDataConsumerDAQModule.hpp
+++ b/test/FakeDataConsumerDAQModule.hpp
@@ -26,25 +26,25 @@ namespace dunedaq::appfwk {
  * @brief FakeDataConsumerDAQModule creates vectors of ints and sends them
  * downstream
  */
-class FakeDataConsumerDAQModule : public DAQModule {
+class FakeDataConsumerDAQModule : public DAQModule
+{
 public:
   /**
    * @brief FakeDataConsumerDAQModule Constructor
    * @param name Instance name for this FakeDataConsumerDAQModule instance
    */
-  explicit FakeDataConsumerDAQModule(const std::string &name);
+  explicit FakeDataConsumerDAQModule(const std::string& name);
 
-  void execute_command(const std::string &cmd,
-                       const std::vector<std::string> &args = {}) override;
+  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
 
-  FakeDataConsumerDAQModule(const FakeDataConsumerDAQModule &) =
-      delete; ///< FakeDataConsumerDAQModule is not copy-constructible
-  FakeDataConsumerDAQModule &operator=(const FakeDataConsumerDAQModule &) =
-      delete; ///< FakeDataConsumerDAQModule is not copy-assignable
-  FakeDataConsumerDAQModule(FakeDataConsumerDAQModule &&) =
-      delete; ///< FakeDataConsumerDAQModule is not move-constructible
-  FakeDataConsumerDAQModule &operator=(FakeDataConsumerDAQModule &&) =
-      delete; ///< FakeDataConsumerDAQModule is not move-assignable
+  FakeDataConsumerDAQModule(const FakeDataConsumerDAQModule&) =
+    delete; ///< FakeDataConsumerDAQModule is not copy-constructible
+  FakeDataConsumerDAQModule& operator=(const FakeDataConsumerDAQModule&) =
+    delete; ///< FakeDataConsumerDAQModule is not copy-assignable
+  FakeDataConsumerDAQModule(FakeDataConsumerDAQModule&&) =
+    delete; ///< FakeDataConsumerDAQModule is not move-constructible
+  FakeDataConsumerDAQModule& operator=(FakeDataConsumerDAQModule&&) =
+    delete; ///< FakeDataConsumerDAQModule is not move-assignable
 
 private:
   // Commands

--- a/test/FakeDataProducerDAQModule.cpp
+++ b/test/FakeDataProducerDAQModule.cpp
@@ -1,5 +1,6 @@
 /**
- * @file FakeDataProducerDAQModule.cc FakeDataProducerDAQModule class implementation
+ * @file FakeDataProducerDAQModule.cc FakeDataProducerDAQModule class
+ * implementation
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -19,18 +20,13 @@
 #define TRACE_NAME "FakeDataProducer" // NOLINT
 
 dunedaq::appfwk::FakeDataProducerDAQModule::FakeDataProducerDAQModule(
-  const std::string & name)
-  : DAQModule(name)
-  , queueTimeout_(100)
-  , thread_(std::bind(&FakeDataProducerDAQModule::do_work, this))
-  , outputQueue_(nullptr)
-{}
+    const std::string &name)
+    : DAQModule(name), queueTimeout_(100),
+      thread_(std::bind(&FakeDataProducerDAQModule::do_work, this)),
+      outputQueue_(nullptr) {}
 
-void
-dunedaq::appfwk::FakeDataProducerDAQModule::execute_command(
-  const std::string& cmd,
-  const std::vector<std::string>& args)
-{
+void dunedaq::appfwk::FakeDataProducerDAQModule::execute_command(
+    const std::string &cmd, const std::vector<std::string> &args) {
   if (cmd == "configure" || cmd == "Configure") {
     do_configure();
   } else if (cmd == "start" || cmd == "Start") {
@@ -42,32 +38,26 @@ dunedaq::appfwk::FakeDataProducerDAQModule::execute_command(
   }
 }
 
-std::string
-dunedaq::appfwk::FakeDataProducerDAQModule::do_configure()
-{
+std::string dunedaq::appfwk::FakeDataProducerDAQModule::do_configure() {
 
-  outputQueue_.reset(
-    new DAQSink<std::vector<int>>(configuration_["output"].get<std::string>()));
+  outputQueue_.reset(new DAQSink<std::vector<int>>(
+      configuration_["output"].get<std::string>()));
 
   nIntsPerVector_ = configuration_.value<int>("nIntsPerVector", 10);
   starting_int_ = configuration_.value<int>("starting_int", -4);
   ending_int_ = configuration_.value<int>("ending_int", 14);
   wait_between_sends_ms_ =
-    configuration_.value<int>("wait_between_sends_ms", 1000);
+      configuration_.value<int>("wait_between_sends_ms", 1000);
 
   return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataProducerDAQModule::do_start()
-{
+std::string dunedaq::appfwk::FakeDataProducerDAQModule::do_start() {
   thread_.start_working_thread_();
   return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataProducerDAQModule::do_stop()
-{
+std::string dunedaq::appfwk::FakeDataProducerDAQModule::do_stop() {
   thread_.stop_working_thread_();
   return "Success";
 }
@@ -78,12 +68,10 @@ dunedaq::appfwk::FakeDataProducerDAQModule::do_stop()
  * @param ints Vector to format
  * @return TraceStreamer Instance
  */
-TraceStreamer&
-operator<<(TraceStreamer& t, std::vector<int> ints)
-{
+TraceStreamer &operator<<(TraceStreamer &t, std::vector<int> ints) {
   t << "{";
   bool first = true;
-  for (auto& i : ints) {
+  for (auto &i : ints) {
     if (!first)
       t << ", ";
     first = false;
@@ -92,9 +80,7 @@ operator<<(TraceStreamer& t, std::vector<int> ints)
   return t << "}";
 }
 
-void
-dunedaq::appfwk::FakeDataProducerDAQModule::do_work()
-{
+void dunedaq::appfwk::FakeDataProducerDAQModule::do_work() {
   int current_int = starting_int_;
   size_t counter = 0;
   while (thread_.thread_running()) {
@@ -117,14 +103,15 @@ dunedaq::appfwk::FakeDataProducerDAQModule::do_work()
     outputQueue_->push(std::move(output), queueTimeout_);
     auto endtime = std::chrono::steady_clock::now();
     if (std::chrono::duration_cast<decltype(queueTimeout_)>(
-          endtime - starttime) > queueTimeout_) {
+            endtime - starttime) > queueTimeout_) {
       TLOG(TLVL_WARNING)
-        << get_name() << ": Timeout attempting to push vector onto outputQueue";
+          << get_name()
+          << ": Timeout attempting to push vector onto outputQueue";
     }
 
     TLOG(TLVL_DEBUG) << get_name() << ": Start of sleep between sends";
     std::this_thread::sleep_for(
-      std::chrono::milliseconds(wait_between_sends_ms_));
+        std::chrono::milliseconds(wait_between_sends_ms_));
     TLOG(TLVL_DEBUG) << get_name() << ": End of do_work loop";
     counter++;
   }

--- a/test/FakeDataProducerDAQModule.hpp
+++ b/test/FakeDataProducerDAQModule.hpp
@@ -26,25 +26,25 @@ namespace dunedaq::appfwk {
  * @brief FakeDataProducerDAQModule creates vectors of ints and sends them
  * downstream
  */
-class FakeDataProducerDAQModule : public DAQModule {
+class FakeDataProducerDAQModule : public DAQModule
+{
 public:
   /**
    * @brief FakeDataProducerDAQModule Constructor
    * @param name Instance name for this FakeDataProducerDAQModule instance
    */
-  explicit FakeDataProducerDAQModule(const std::string &name);
+  explicit FakeDataProducerDAQModule(const std::string& name);
 
-  void execute_command(const std::string &cmd,
-                       const std::vector<std::string> &args = {}) override;
+  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
 
-  FakeDataProducerDAQModule(const FakeDataProducerDAQModule &) =
-      delete; ///< FakeDataProducerDAQModule is not copy-constructible
-  FakeDataProducerDAQModule &operator=(const FakeDataProducerDAQModule &) =
-      delete; ///< FakeDataProducerDAQModule is not copy-assignable
-  FakeDataProducerDAQModule(FakeDataProducerDAQModule &&) =
-      delete; ///< FakeDataProducerDAQModule is not move-constructible
-  FakeDataProducerDAQModule &operator=(FakeDataProducerDAQModule &&) =
-      delete; ///< FakeDataProducerDAQModule is not move-assignable
+  FakeDataProducerDAQModule(const FakeDataProducerDAQModule&) =
+    delete; ///< FakeDataProducerDAQModule is not copy-constructible
+  FakeDataProducerDAQModule& operator=(const FakeDataProducerDAQModule&) =
+    delete; ///< FakeDataProducerDAQModule is not copy-assignable
+  FakeDataProducerDAQModule(FakeDataProducerDAQModule&&) =
+    delete; ///< FakeDataProducerDAQModule is not move-constructible
+  FakeDataProducerDAQModule& operator=(FakeDataProducerDAQModule&&) =
+    delete; ///< FakeDataProducerDAQModule is not move-assignable
 
 private:
   // Commands

--- a/test/FakeDataProducerDAQModule.hpp
+++ b/test/FakeDataProducerDAQModule.hpp
@@ -26,26 +26,25 @@ namespace dunedaq::appfwk {
  * @brief FakeDataProducerDAQModule creates vectors of ints and sends them
  * downstream
  */
-class FakeDataProducerDAQModule : public DAQModule
-{
+class FakeDataProducerDAQModule : public DAQModule {
 public:
   /**
    * @brief FakeDataProducerDAQModule Constructor
    * @param name Instance name for this FakeDataProducerDAQModule instance
-  */
-  explicit FakeDataProducerDAQModule( const std::string & name);
+   */
+  explicit FakeDataProducerDAQModule(const std::string &name);
 
-  void execute_command(const std::string& cmd,
-                       const std::vector<std::string>& args = {}) override;
+  void execute_command(const std::string &cmd,
+                       const std::vector<std::string> &args = {}) override;
 
-  FakeDataProducerDAQModule(const FakeDataProducerDAQModule&) =
-    delete; ///< FakeDataProducerDAQModule is not copy-constructible
-  FakeDataProducerDAQModule& operator=(const FakeDataProducerDAQModule&) =
-    delete; ///< FakeDataProducerDAQModule is not copy-assignable
-  FakeDataProducerDAQModule(FakeDataProducerDAQModule&&) =
-    delete; ///< FakeDataProducerDAQModule is not move-constructible
-  FakeDataProducerDAQModule& operator=(FakeDataProducerDAQModule&&) =
-    delete; ///< FakeDataProducerDAQModule is not move-assignable
+  FakeDataProducerDAQModule(const FakeDataProducerDAQModule &) =
+      delete; ///< FakeDataProducerDAQModule is not copy-constructible
+  FakeDataProducerDAQModule &operator=(const FakeDataProducerDAQModule &) =
+      delete; ///< FakeDataProducerDAQModule is not copy-assignable
+  FakeDataProducerDAQModule(FakeDataProducerDAQModule &&) =
+      delete; ///< FakeDataProducerDAQModule is not move-constructible
+  FakeDataProducerDAQModule &operator=(FakeDataProducerDAQModule &&) =
+      delete; ///< FakeDataProducerDAQModule is not move-assignable
 
 private:
   // Commands

--- a/test/daq_sink_source.cxx
+++ b/test/daq_sink_source.cxx
@@ -1,5 +1,6 @@
 /**
- * @file daq_sink_source.cxx Test application which demonstrates the functionality of the QueueRegistry, DAQSink, and DAQSource
+ * @file daq_sink_source.cxx Test application which demonstrates the
+ * functionality of the QueueRegistry, DAQSink, and DAQSource
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -15,7 +16,7 @@
 
 namespace dunedaq::appfwk {
 std::unique_ptr<CommandFacility> CommandFacility::handle_ =
-  std::unique_ptr<CommandFacility>();
+    std::unique_ptr<CommandFacility>();
 } // namespace dunedaq::appfwk
 
 using namespace dunedaq::appfwk;
@@ -25,14 +26,11 @@ using namespace dunedaq::appfwk;
  * @param argc Number of arguments
  * @param argv arguments
  * @return Status code
-*/
-int
-main(int argc, char const* argv[])
-{
+ */
+int main(int argc, char const *argv[]) {
 
   std::map<std::string, QueueConfig> queuemap = {
-    { "dummy", { QueueConfig::queue_kind::kStdDeQueue, 100 } }
-  };
+      {"dummy", {QueueConfig::queue_kind::kStdDeQueue, 100}}};
 
   QueueRegistry::get().configure(queuemap);
 
@@ -40,7 +38,7 @@ main(int argc, char const* argv[])
   TLOG(TLVL_DEBUG) << "Expecting queue mismatch error";
   try {
     auto source = new DAQSource<int>("dummy");
-  } catch (dunedaq::appfwk::DAQSourceConstructionFailed& e) {
+  } catch (dunedaq::appfwk::DAQSourceConstructionFailed &e) {
     ers::error(e);
     TLOG(TLVL_DEBUG) << "OK, got it. Carrying on";
   }

--- a/test/daq_sink_source.cxx
+++ b/test/daq_sink_source.cxx
@@ -15,8 +15,7 @@
 #include "ers/ers.h"
 
 namespace dunedaq::appfwk {
-std::unique_ptr<CommandFacility> CommandFacility::handle_ =
-    std::unique_ptr<CommandFacility>();
+std::unique_ptr<CommandFacility> CommandFacility::handle_ = std::unique_ptr<CommandFacility>();
 } // namespace dunedaq::appfwk
 
 using namespace dunedaq::appfwk;
@@ -27,10 +26,11 @@ using namespace dunedaq::appfwk;
  * @param argv arguments
  * @return Status code
  */
-int main(int argc, char const *argv[]) {
+int
+main(int argc, char const* argv[])
+{
 
-  std::map<std::string, QueueConfig> queuemap = {
-      {"dummy", {QueueConfig::queue_kind::kStdDeQueue, 100}}};
+  std::map<std::string, QueueConfig> queuemap = { { "dummy", { QueueConfig::queue_kind::kStdDeQueue, 100 } } };
 
   QueueRegistry::get().configure(queuemap);
 
@@ -38,7 +38,7 @@ int main(int argc, char const *argv[]) {
   TLOG(TLVL_DEBUG) << "Expecting queue mismatch error";
   try {
     auto source = new DAQSource<int>("dummy");
-  } catch (dunedaq::appfwk::DAQSourceConstructionFailed &e) {
+  } catch (dunedaq::appfwk::DAQSourceConstructionFailed& e) {
     ers::error(e);
     TLOG(TLVL_DEBUG) << "OK, got it. Carrying on";
   }

--- a/test/echo_test_app.cxx
+++ b/test/echo_test_app.cxx
@@ -16,15 +16,13 @@
 namespace dunedaq::appfwk {
 /**
  * @brief ModuleList for the echo_test_app
-*/
-class echo_test_app_contructor : public GraphConstructor
-{
+ */
+class echo_test_app_contructor : public GraphConstructor {
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap& user_module_map,
-                      CommandOrderMap& command_order_map) override
-  {
+  void ConstructGraph(DAQModuleMap &user_module_map,
+                      CommandOrderMap &command_order_map) override {
     user_module_map["debugLogger"].reset(
-      new DebugLoggingDAQModule("debugLogger"));
+        new DebugLoggingDAQModule("debugLogger"));
   }
 };
 } // namespace dunedaq::appfwk
@@ -34,12 +32,11 @@ class echo_test_app_contructor : public GraphConstructor
  * @param argc Number of arguments
  * @param argv Arguments
  * @return Status code from DAQProcess::listen
-*/
-int
-main(int argc, char* argv[])
-{
+ */
+int main(int argc, char *argv[]) {
   auto args =
-    dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
+      dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc,
+                                                                         argv);
 
   dunedaq::appfwk::DAQProcess theDAQProcess(args);
 

--- a/test/echo_test_app.cxx
+++ b/test/echo_test_app.cxx
@@ -17,12 +17,12 @@ namespace dunedaq::appfwk {
 /**
  * @brief ModuleList for the echo_test_app
  */
-class echo_test_app_contructor : public GraphConstructor {
+class echo_test_app_contructor : public GraphConstructor
+{
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap &user_module_map,
-                      CommandOrderMap &command_order_map) override {
-    user_module_map["debugLogger"].reset(
-        new DebugLoggingDAQModule("debugLogger"));
+  void ConstructGraph(DAQModuleMap& user_module_map, CommandOrderMap& command_order_map) override
+  {
+    user_module_map["debugLogger"].reset(new DebugLoggingDAQModule("debugLogger"));
   }
 };
 } // namespace dunedaq::appfwk
@@ -33,10 +33,10 @@ class echo_test_app_contructor : public GraphConstructor {
  * @param argv Arguments
  * @return Status code from DAQProcess::listen
  */
-int main(int argc, char *argv[]) {
-  auto args =
-      dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc,
-                                                                         argv);
+int
+main(int argc, char* argv[])
+{
+  auto args = dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
 
   dunedaq::appfwk::DAQProcess theDAQProcess(args);
 

--- a/test/producer_consumer_test_app.cxx
+++ b/test/producer_consumer_test_app.cxx
@@ -23,43 +23,43 @@
 namespace dunedaq::appfwk {
 /**
  * @brief ModuleList for the producer_consumer_test_app
-*/
-class producer_consumer_test_app_constructor : public GraphConstructor 
-{
+ */
+class producer_consumer_test_app_constructor : public GraphConstructor {
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap& user_module_map,
-                      CommandOrderMap& command_order_map) override
-  {
+  void ConstructGraph(DAQModuleMap &user_module_map,
+                      CommandOrderMap &command_order_map) override {
 
     std::map<std::string, QueueConfig> queue_configuration;
-    queue_configuration["producerToFanOut"].kind = QueueConfig::queue_kind::kStdDeQueue;
+    queue_configuration["producerToFanOut"].kind =
+        QueueConfig::queue_kind::kStdDeQueue;
     queue_configuration["producerToFanOut"].size = 10;
-    queue_configuration["fanOutToConsumer1"].kind = QueueConfig::queue_kind::kStdDeQueue;
+    queue_configuration["fanOutToConsumer1"].kind =
+        QueueConfig::queue_kind::kStdDeQueue;
     queue_configuration["fanOutToConsumer1"].size = 5;
-    queue_configuration["fanOutToConsumer2"].kind = QueueConfig::queue_kind::kStdDeQueue;
+    queue_configuration["fanOutToConsumer2"].kind =
+        QueueConfig::queue_kind::kStdDeQueue;
     queue_configuration["fanOutToConsumer2"].size = 5;
     QueueRegistry::get().configure(queue_configuration);
 
     auto producerConfig = R"({ "output" : "producerToFanOut" })"_json;
     auto fanOutConfig =
-      R"({ "input" : "producerToFanOut", "outputs" : [ "fanOutToConsumer1", "fanOutToConsumer2" ], "fanout_mode" : "RoundRobin" })"_json;
+        R"({ "input" : "producerToFanOut", "outputs" : [ "fanOutToConsumer1", "fanOutToConsumer2" ], "fanout_mode" : "RoundRobin" })"_json;
     auto consumer1Config = R"({ "input" : "fanOutToConsumer1" })"_json;
     auto consumer2Config = R"({ "input" : "fanOutToConsumer2" })"_json;
 
     user_module_map["producer"].reset(new FakeDataProducerDAQModule("prod"));
     user_module_map["producer"]->configure(producerConfig);
     user_module_map["fanOut"].reset(
-      new FanOutDAQModule<std::vector<int>>("fanOut"));
+        new FanOutDAQModule<std::vector<int>>("fanOut"));
     user_module_map["fanOut"]->configure(fanOutConfig);
     user_module_map["consumer1"].reset(new FakeDataConsumerDAQModule("C1"));
     user_module_map["consumer1"]->configure(consumer1Config);
     user_module_map["consumer2"].reset(new FakeDataConsumerDAQModule("C2"));
     user_module_map["consumer2"]->configure(consumer2Config);
 
-    command_order_map["start"] = {
-      "consumer1", "consumer2", "fanOut", "producer"
-    };
-    command_order_map["stop"] = { "producer" };
+    command_order_map["start"] = {"consumer1", "consumer2", "fanOut",
+                                  "producer"};
+    command_order_map["stop"] = {"producer"};
   }
 };
 } // namespace dunedaq::appfwk
@@ -70,16 +70,15 @@ class producer_consumer_test_app_constructor : public GraphConstructor
  * @param argv Arguments
  * @return Status code from DAQProcess::listen
  */
-int
-main(int argc, char* argv[])
-{
+int main(int argc, char *argv[]) {
   auto args =
-    dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
+      dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc,
+                                                                         argv);
 
   dunedaq::appfwk::DAQProcess theDAQProcess(args);
 
   dunedaq::appfwk::producer_consumer_test_app_constructor gc;
-  theDAQProcess.register_modules( gc );
+  theDAQProcess.register_modules(gc);
 
   return theDAQProcess.listen();
 }

--- a/test/producer_consumer_test_app.cxx
+++ b/test/producer_consumer_test_app.cxx
@@ -24,42 +24,38 @@ namespace dunedaq::appfwk {
 /**
  * @brief ModuleList for the producer_consumer_test_app
  */
-class producer_consumer_test_app_constructor : public GraphConstructor {
+class producer_consumer_test_app_constructor : public GraphConstructor
+{
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap &user_module_map,
-                      CommandOrderMap &command_order_map) override {
+  void ConstructGraph(DAQModuleMap& user_module_map, CommandOrderMap& command_order_map) override
+  {
 
     std::map<std::string, QueueConfig> queue_configuration;
-    queue_configuration["producerToFanOut"].kind =
-        QueueConfig::queue_kind::kStdDeQueue;
+    queue_configuration["producerToFanOut"].kind = QueueConfig::queue_kind::kStdDeQueue;
     queue_configuration["producerToFanOut"].size = 10;
-    queue_configuration["fanOutToConsumer1"].kind =
-        QueueConfig::queue_kind::kStdDeQueue;
+    queue_configuration["fanOutToConsumer1"].kind = QueueConfig::queue_kind::kStdDeQueue;
     queue_configuration["fanOutToConsumer1"].size = 5;
-    queue_configuration["fanOutToConsumer2"].kind =
-        QueueConfig::queue_kind::kStdDeQueue;
+    queue_configuration["fanOutToConsumer2"].kind = QueueConfig::queue_kind::kStdDeQueue;
     queue_configuration["fanOutToConsumer2"].size = 5;
     QueueRegistry::get().configure(queue_configuration);
 
     auto producerConfig = R"({ "output" : "producerToFanOut" })"_json;
     auto fanOutConfig =
-        R"({ "input" : "producerToFanOut", "outputs" : [ "fanOutToConsumer1", "fanOutToConsumer2" ], "fanout_mode" : "RoundRobin" })"_json;
+      R"({ "input" : "producerToFanOut", "outputs" : [ "fanOutToConsumer1", "fanOutToConsumer2" ], "fanout_mode" : "RoundRobin" })"_json;
     auto consumer1Config = R"({ "input" : "fanOutToConsumer1" })"_json;
     auto consumer2Config = R"({ "input" : "fanOutToConsumer2" })"_json;
 
     user_module_map["producer"].reset(new FakeDataProducerDAQModule("prod"));
     user_module_map["producer"]->configure(producerConfig);
-    user_module_map["fanOut"].reset(
-        new FanOutDAQModule<std::vector<int>>("fanOut"));
+    user_module_map["fanOut"].reset(new FanOutDAQModule<std::vector<int>>("fanOut"));
     user_module_map["fanOut"]->configure(fanOutConfig);
     user_module_map["consumer1"].reset(new FakeDataConsumerDAQModule("C1"));
     user_module_map["consumer1"]->configure(consumer1Config);
     user_module_map["consumer2"].reset(new FakeDataConsumerDAQModule("C2"));
     user_module_map["consumer2"]->configure(consumer2Config);
 
-    command_order_map["start"] = {"consumer1", "consumer2", "fanOut",
-                                  "producer"};
-    command_order_map["stop"] = {"producer"};
+    command_order_map["start"] = { "consumer1", "consumer2", "fanOut", "producer" };
+    command_order_map["stop"] = { "producer" };
   }
 };
 } // namespace dunedaq::appfwk
@@ -70,10 +66,10 @@ class producer_consumer_test_app_constructor : public GraphConstructor {
  * @param argv Arguments
  * @return Status code from DAQProcess::listen
  */
-int main(int argc, char *argv[]) {
-  auto args =
-      dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc,
-                                                                         argv);
+int
+main(int argc, char* argv[])
+{
+  auto args = dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
 
   dunedaq::appfwk::DAQProcess theDAQProcess(args);
 

--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -42,56 +42,60 @@ std::string queue_type = "StdDeQueue";
 
 auto timeout = std::chrono::milliseconds(100); ///< Queue's timeout
 
-
 /**
  * @brief Queue instance for test
-*/
+ */
 std::unique_ptr<dunedaq::appfwk::StdDeQueue<int>> queue = nullptr;
 
-constexpr int nelements = 100; ///< Number of elements to push to the Queue (total)
-int n_adding_threads = 1; ///< Number of threads which will call push
+constexpr int nelements =
+    100;                    ///< Number of elements to push to the Queue (total)
+int n_adding_threads = 1;   ///< Number of threads which will call push
 int n_removing_threads = 1; ///< Number of threads which will call pop
 
 int avg_milliseconds_between_pushes = 5; ///< Target average rate of pushes
-int avg_milliseconds_between_pops = 5; ///< Target average rate of pops
+int avg_milliseconds_between_pops = 5;   ///< Target average rate of pops
 
-std::atomic<size_t> queue_size = 0; ///< Queue's current size
+std::atomic<size_t> queue_size = 0;     ///< Queue's current size
 std::atomic<size_t> max_queue_size = 0; ///< Queue's maximum size
 
 std::atomic<int> push_attempts = 0; ///< Number of push attempts in the test
-std::atomic<int> pop_attempts = 0; ///< Number of pop attempts in the test
-std::atomic<int> successful_pushes = 0; ///< Number of successful pushes in the test
+std::atomic<int> pop_attempts = 0;  ///< Number of pop attempts in the test
+std::atomic<int> successful_pushes =
+    0; ///< Number of successful pushes in the test
 std::atomic<int> successful_pops = 0; ///< Number of successful pops in the test
-std::atomic<int> timeout_pushes = 0; ///< Number of pushes which timed out
-std::atomic<int> timeout_pops = 0; ///< Number of pops which timed out
-std::atomic<int> throw_pushes = 0; ///< Number of pushes which threw an exception
+std::atomic<int> timeout_pushes = 0;  ///< Number of pushes which timed out
+std::atomic<int> timeout_pops = 0;    ///< Number of pops which timed out
+std::atomic<int> throw_pushes =
+    0;                           ///< Number of pushes which threw an exception
 std::atomic<int> throw_pops = 0; ///< Number of pops which threw an exception
 
-double initial_capacity_used = 0; ///< The initial portion of the Queue which was full.
+double initial_capacity_used =
+    0; ///< The initial portion of the Queue which was full.
 
 /**
  * @brief A time-based seed for the random number generators
-*/
+ */
 auto relatively_random_seed =
-  std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::system_clock::now().time_since_epoch())
-    .count() %
-  1000;
-std::default_random_engine generator(relatively_random_seed); ///< Random number generator with time-based seed
-std::unique_ptr<std::uniform_int_distribution<int>> push_distribution = nullptr;///< Random number distribution to use for push waits
-std::unique_ptr<std::uniform_int_distribution<int>> pop_distribution = nullptr; ///< Random number distribution to use for pop waits
+    std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch())
+        .count() %
+    1000;
+std::default_random_engine generator(
+    relatively_random_seed); ///< Random number generator with time-based seed
+std::unique_ptr<std::uniform_int_distribution<int>> push_distribution =
+    nullptr; ///< Random number distribution to use for push waits
+std::unique_ptr<std::uniform_int_distribution<int>> pop_distribution =
+    nullptr; ///< Random number distribution to use for pop waits
 
 /**
  * @brief Put elements onto the queue
-*/
-void
-add_things()
-{
+ */
+void add_things() {
 
   for (int i = 0; i < nelements / n_adding_threads; ++i) {
 
     std::this_thread::sleep_for(
-      std::chrono::milliseconds((*push_distribution)(generator)));
+        std::chrono::milliseconds((*push_distribution)(generator)));
 
     while (!queue->can_push()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -109,9 +113,10 @@ add_things()
       auto starttime = std::chrono::steady_clock::now();
       queue->push(std::move(i), timeout);
       if (std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - starttime) < timeout) {
+              std::chrono::steady_clock::now() - starttime) < timeout) {
         successful_pushes++;
-        auto size = queue_size.fetch_add(1) + 1; // fetch_add returns previous value
+        auto size =
+            queue_size.fetch_add(1) + 1; // fetch_add returns previous value
         if (size > max_queue_size) {
           max_queue_size = size;
         }
@@ -122,7 +127,7 @@ add_things()
       msg << "Thread #" << std::this_thread::get_id() << ": completed push";
       TLOG(TLVL_DEBUG) << msg.str();
 
-    } catch (const std::runtime_error& err) {
+    } catch (const std::runtime_error &err) {
       TLOG(TLVL_WARNING) << "Exception thrown during push attempt: "
                          << err.what();
       throw_pushes++;
@@ -132,15 +137,13 @@ add_things()
 
 /**
  * @brief Pop elements off of the queue
-*/
-void
-remove_things()
-{
+ */
+void remove_things() {
 
   for (int i = 0; i < nelements / n_removing_threads; ++i) {
 
     std::this_thread::sleep_for(
-      std::chrono::milliseconds((*pop_distribution)(generator)));
+        std::chrono::milliseconds((*pop_distribution)(generator)));
 
     while (!queue->can_pop()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -164,66 +167,62 @@ remove_things()
       TLOG(TLVL_DEBUG) << msg.str();
 
       if (std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - starttime) < timeout) {
+              std::chrono::steady_clock::now() - starttime) < timeout) {
         successful_pops++;
         queue_size--;
       } else {
         timeout_pops++;
       }
-    } catch (const std::runtime_error& e) {
+    } catch (const std::runtime_error &e) {
       TLOG(TLVL_WARNING) << "Exception thrown during pop attempt: " << e.what();
       throw_pops++;
     }
   }
 }
 
-} // namespace ""
+} // namespace
 
-int
-main(int argc, char* argv[])
-{
+int main(int argc, char *argv[]) {
 
   std::ostringstream descstr;
   descstr << argv[0] << " known arguments ";
 
   std::ostringstream push_threads_desc;
   push_threads_desc
-    << "# of threads you want pushing elements onto the queue (default is "
-    << n_adding_threads << ")";
+      << "# of threads you want pushing elements onto the queue (default is "
+      << n_adding_threads << ")";
 
   std::ostringstream pop_threads_desc;
   pop_threads_desc
-    << "# of threads you want popping elements off the queue (default is "
-    << n_removing_threads << ")";
+      << "# of threads you want popping elements off the queue (default is "
+      << n_removing_threads << ")";
 
   std::ostringstream push_pause_desc;
   push_pause_desc
-    << "average time in milliseconds between a thread's pushes (default is "
-    << avg_milliseconds_between_pushes << ")";
+      << "average time in milliseconds between a thread's pushes (default is "
+      << avg_milliseconds_between_pushes << ")";
 
   std::ostringstream pop_pause_desc;
   pop_pause_desc
-    << "average time in milliseconds between a thread's pops (default is "
-    << avg_milliseconds_between_pops << ")";
+      << "average time in milliseconds between a thread's pops (default is "
+      << avg_milliseconds_between_pops << ")";
 
   std::ostringstream capacity_used_desc;
   capacity_used_desc
-    << "fraction of the queue's capacity filled at start (default is "
-    << initial_capacity_used << ")";
+      << "fraction of the queue's capacity filled at start (default is "
+      << initial_capacity_used << ")";
 
   bpo::options_description desc(descstr.str());
-  desc.add_options()("queue_type",
-                     bpo::value<std::string>(),
+  desc.add_options()("queue_type", bpo::value<std::string>(),
                      "Type of queue instance you want to test (default is "
                      "StdDeQueue) (supported "
                      "types are: StdDeQueue)")(
-    "push_threads", bpo::value<int>(), push_threads_desc.str().c_str())(
-    "pop_threads", bpo::value<int>(), pop_threads_desc.str().c_str())(
-    "pause_between_pushes", bpo::value<int>(), push_pause_desc.str().c_str())(
-    "pause_between_pops", bpo::value<int>(), pop_pause_desc.str().c_str())(
-    "initial_capacity_used",
-    bpo::value<double>(),
-    capacity_used_desc.str().c_str())("help,h", "produce help message");
+      "push_threads", bpo::value<int>(), push_threads_desc.str().c_str())(
+      "pop_threads", bpo::value<int>(), pop_threads_desc.str().c_str())(
+      "pause_between_pushes", bpo::value<int>(), push_pause_desc.str().c_str())(
+      "pause_between_pops", bpo::value<int>(), pop_pause_desc.str().c_str())(
+      "initial_capacity_used", bpo::value<double>(),
+      capacity_used_desc.str().c_str())("help,h", "produce help message");
 
   bpo::variables_map vm;
   bpo::store(bpo::parse_command_line(argc, argv, desc), vm);
@@ -253,7 +252,7 @@ main(int argc, char* argv[])
 
     if (n_adding_threads <= 0) {
       throw std::domain_error(
-        "# of pushing threads must be a positive integer");
+          "# of pushing threads must be a positive integer");
     }
   }
 
@@ -262,7 +261,7 @@ main(int argc, char* argv[])
 
     if (n_removing_threads <= 0) {
       throw std::domain_error(
-        "# of popping threads must be a positive integer");
+          "# of popping threads must be a positive integer");
     }
   }
 
@@ -294,18 +293,18 @@ main(int argc, char* argv[])
   }
 
   push_distribution.reset(new std::uniform_int_distribution<int>(
-    0, 2 * 1000 * avg_milliseconds_between_pushes));
+      0, 2 * 1000 * avg_milliseconds_between_pushes));
   pop_distribution.reset(new std::uniform_int_distribution<int>(
-    0, 2 * 1000 * avg_milliseconds_between_pops));
+      0, 2 * 1000 * avg_milliseconds_between_pops));
 
   TLOG(TLVL_INFO)
-    << n_adding_threads << " thread(s) pushing " << nelements
-    << " elements between them, each thread has an average time of "
-    << avg_milliseconds_between_pushes << " milliseconds between pushes";
+      << n_adding_threads << " thread(s) pushing " << nelements
+      << " elements between them, each thread has an average time of "
+      << avg_milliseconds_between_pushes << " milliseconds between pushes";
   TLOG(TLVL_INFO)
-    << n_removing_threads << " thread(s) popping " << nelements
-    << " elements between them, each thread has an average time of "
-    << avg_milliseconds_between_pops << " milliseconds between pops";
+      << n_removing_threads << " thread(s) popping " << nelements
+      << " elements between them, each thread has an average time of "
+      << avg_milliseconds_between_pops << " milliseconds between pops";
 
 /**
  * \todo Add capacity constructor to Queue interface so that this code section
@@ -344,11 +343,11 @@ main(int argc, char* argv[])
     removers.emplace_back(remove_things);
   }
 
-  for (auto& adder : adders) {
+  for (auto &adder : adders) {
     adder.join();
   }
 
-  for (auto& remover : removers) {
+  for (auto &remover : removers) {
     remover.join();
   }
 

--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -47,10 +47,9 @@ auto timeout = std::chrono::milliseconds(100); ///< Queue's timeout
  */
 std::unique_ptr<dunedaq::appfwk::StdDeQueue<int>> queue = nullptr;
 
-constexpr int nelements =
-    100;                    ///< Number of elements to push to the Queue (total)
-int n_adding_threads = 1;   ///< Number of threads which will call push
-int n_removing_threads = 1; ///< Number of threads which will call pop
+constexpr int nelements = 100; ///< Number of elements to push to the Queue (total)
+int n_adding_threads = 1;      ///< Number of threads which will call push
+int n_removing_threads = 1;    ///< Number of threads which will call pop
 
 int avg_milliseconds_between_pushes = 5; ///< Target average rate of pushes
 int avg_milliseconds_between_pops = 5;   ///< Target average rate of pops
@@ -58,44 +57,39 @@ int avg_milliseconds_between_pops = 5;   ///< Target average rate of pops
 std::atomic<size_t> queue_size = 0;     ///< Queue's current size
 std::atomic<size_t> max_queue_size = 0; ///< Queue's maximum size
 
-std::atomic<int> push_attempts = 0; ///< Number of push attempts in the test
-std::atomic<int> pop_attempts = 0;  ///< Number of pop attempts in the test
-std::atomic<int> successful_pushes =
-    0; ///< Number of successful pushes in the test
-std::atomic<int> successful_pops = 0; ///< Number of successful pops in the test
-std::atomic<int> timeout_pushes = 0;  ///< Number of pushes which timed out
-std::atomic<int> timeout_pops = 0;    ///< Number of pops which timed out
-std::atomic<int> throw_pushes =
-    0;                           ///< Number of pushes which threw an exception
-std::atomic<int> throw_pops = 0; ///< Number of pops which threw an exception
+std::atomic<int> push_attempts = 0;     ///< Number of push attempts in the test
+std::atomic<int> pop_attempts = 0;      ///< Number of pop attempts in the test
+std::atomic<int> successful_pushes = 0; ///< Number of successful pushes in the test
+std::atomic<int> successful_pops = 0;   ///< Number of successful pops in the test
+std::atomic<int> timeout_pushes = 0;    ///< Number of pushes which timed out
+std::atomic<int> timeout_pops = 0;      ///< Number of pops which timed out
+std::atomic<int> throw_pushes = 0;      ///< Number of pushes which threw an exception
+std::atomic<int> throw_pops = 0;        ///< Number of pops which threw an exception
 
-double initial_capacity_used =
-    0; ///< The initial portion of the Queue which was full.
+double initial_capacity_used = 0; ///< The initial portion of the Queue which was full.
 
 /**
  * @brief A time-based seed for the random number generators
  */
 auto relatively_random_seed =
-    std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch())
-        .count() %
-    1000;
-std::default_random_engine generator(
-    relatively_random_seed); ///< Random number generator with time-based seed
+  std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() %
+  1000;
+std::default_random_engine generator(relatively_random_seed); ///< Random number generator with time-based seed
 std::unique_ptr<std::uniform_int_distribution<int>> push_distribution =
-    nullptr; ///< Random number distribution to use for push waits
+  nullptr; ///< Random number distribution to use for push waits
 std::unique_ptr<std::uniform_int_distribution<int>> pop_distribution =
-    nullptr; ///< Random number distribution to use for pop waits
+  nullptr; ///< Random number distribution to use for pop waits
 
 /**
  * @brief Put elements onto the queue
  */
-void add_things() {
+void
+add_things()
+{
 
   for (int i = 0; i < nelements / n_adding_threads; ++i) {
 
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds((*push_distribution)(generator)));
+    std::this_thread::sleep_for(std::chrono::milliseconds((*push_distribution)(generator)));
 
     while (!queue->can_push()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -105,18 +99,16 @@ void add_things() {
 
     try {
       std::ostringstream msg;
-      msg << "Thread #" << std::this_thread::get_id()
-          << ": about to push value " << i << " onto queue with can_pop flag "
-          << std::boolalpha << queue->can_pop();
+      msg << "Thread #" << std::this_thread::get_id() << ": about to push value " << i
+          << " onto queue with can_pop flag " << std::boolalpha << queue->can_pop();
       TLOG(TLVL_DEBUG) << msg.str();
 
       auto starttime = std::chrono::steady_clock::now();
       queue->push(std::move(i), timeout);
-      if (std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - starttime) < timeout) {
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime) <
+          timeout) {
         successful_pushes++;
-        auto size =
-            queue_size.fetch_add(1) + 1; // fetch_add returns previous value
+        auto size = queue_size.fetch_add(1) + 1; // fetch_add returns previous value
         if (size > max_queue_size) {
           max_queue_size = size;
         }
@@ -127,9 +119,8 @@ void add_things() {
       msg << "Thread #" << std::this_thread::get_id() << ": completed push";
       TLOG(TLVL_DEBUG) << msg.str();
 
-    } catch (const std::runtime_error &err) {
-      TLOG(TLVL_WARNING) << "Exception thrown during push attempt: "
-                         << err.what();
+    } catch (const std::runtime_error& err) {
+      TLOG(TLVL_WARNING) << "Exception thrown during push attempt: " << err.what();
       throw_pushes++;
     }
   }
@@ -138,12 +129,13 @@ void add_things() {
 /**
  * @brief Pop elements off of the queue
  */
-void remove_things() {
+void
+remove_things()
+{
 
   for (int i = 0; i < nelements / n_removing_threads; ++i) {
 
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds((*pop_distribution)(generator)));
+    std::this_thread::sleep_for(std::chrono::milliseconds((*pop_distribution)(generator)));
 
     while (!queue->can_pop()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -153,27 +145,25 @@ void remove_things() {
     int val = -999;
     try {
       std::ostringstream msg;
-      msg << "Thread #" << std::this_thread::get_id()
-          << ": about to pop from queue with can_push flag " << std::boolalpha
-          << queue->can_push();
+      msg << "Thread #" << std::this_thread::get_id() << ": about to pop from queue with can_push flag "
+          << std::boolalpha << queue->can_push();
       TLOG(TLVL_DEBUG) << msg.str();
 
       auto starttime = std::chrono::steady_clock::now();
       queue->pop(val, timeout);
 
       msg.str(std::string());
-      msg << "Thread #" << std::this_thread::get_id()
-          << ": completed pop, value is " << val;
+      msg << "Thread #" << std::this_thread::get_id() << ": completed pop, value is " << val;
       TLOG(TLVL_DEBUG) << msg.str();
 
-      if (std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - starttime) < timeout) {
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime) <
+          timeout) {
         successful_pops++;
         queue_size--;
       } else {
         timeout_pops++;
       }
-    } catch (const std::runtime_error &e) {
+    } catch (const std::runtime_error& e) {
       TLOG(TLVL_WARNING) << "Exception thrown during pop attempt: " << e.what();
       throw_pops++;
     }
@@ -182,47 +172,40 @@ void remove_things() {
 
 } // namespace
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char* argv[])
+{
 
   std::ostringstream descstr;
   descstr << argv[0] << " known arguments ";
 
   std::ostringstream push_threads_desc;
-  push_threads_desc
-      << "# of threads you want pushing elements onto the queue (default is "
-      << n_adding_threads << ")";
+  push_threads_desc << "# of threads you want pushing elements onto the queue (default is " << n_adding_threads << ")";
 
   std::ostringstream pop_threads_desc;
-  pop_threads_desc
-      << "# of threads you want popping elements off the queue (default is "
-      << n_removing_threads << ")";
+  pop_threads_desc << "# of threads you want popping elements off the queue (default is " << n_removing_threads << ")";
 
   std::ostringstream push_pause_desc;
-  push_pause_desc
-      << "average time in milliseconds between a thread's pushes (default is "
-      << avg_milliseconds_between_pushes << ")";
+  push_pause_desc << "average time in milliseconds between a thread's pushes (default is "
+                  << avg_milliseconds_between_pushes << ")";
 
   std::ostringstream pop_pause_desc;
-  pop_pause_desc
-      << "average time in milliseconds between a thread's pops (default is "
-      << avg_milliseconds_between_pops << ")";
+  pop_pause_desc << "average time in milliseconds between a thread's pops (default is " << avg_milliseconds_between_pops
+                 << ")";
 
   std::ostringstream capacity_used_desc;
-  capacity_used_desc
-      << "fraction of the queue's capacity filled at start (default is "
-      << initial_capacity_used << ")";
+  capacity_used_desc << "fraction of the queue's capacity filled at start (default is " << initial_capacity_used << ")";
 
   bpo::options_description desc(descstr.str());
-  desc.add_options()("queue_type", bpo::value<std::string>(),
+  desc.add_options()("queue_type",
+                     bpo::value<std::string>(),
                      "Type of queue instance you want to test (default is "
                      "StdDeQueue) (supported "
-                     "types are: StdDeQueue)")(
-      "push_threads", bpo::value<int>(), push_threads_desc.str().c_str())(
-      "pop_threads", bpo::value<int>(), pop_threads_desc.str().c_str())(
-      "pause_between_pushes", bpo::value<int>(), push_pause_desc.str().c_str())(
-      "pause_between_pops", bpo::value<int>(), pop_pause_desc.str().c_str())(
-      "initial_capacity_used", bpo::value<double>(),
-      capacity_used_desc.str().c_str())("help,h", "produce help message");
+                     "types are: StdDeQueue)")("push_threads", bpo::value<int>(), push_threads_desc.str().c_str())(
+    "pop_threads", bpo::value<int>(), pop_threads_desc.str().c_str())(
+    "pause_between_pushes", bpo::value<int>(), push_pause_desc.str().c_str())(
+    "pause_between_pops", bpo::value<int>(), pop_pause_desc.str().c_str())(
+    "initial_capacity_used", bpo::value<double>(), capacity_used_desc.str().c_str())("help,h", "produce help message");
 
   bpo::variables_map vm;
   bpo::store(bpo::parse_command_line(argc, argv, desc), vm);
@@ -242,8 +225,7 @@ int main(int argc, char *argv[]) {
   if (queue_type == "StdDeQueue") {
     queue.reset(new dunedaq::appfwk::StdDeQueue<int>("StdDeQueue"));
   } else {
-    TLOG(TLVL_ERROR) << "Unknown queue type \"" << queue_type
-                     << "\" requested for testing";
+    TLOG(TLVL_ERROR) << "Unknown queue type \"" << queue_type << "\" requested for testing";
     return 1;
   }
 
@@ -251,8 +233,7 @@ int main(int argc, char *argv[]) {
     n_adding_threads = vm["push_threads"].as<int>();
 
     if (n_adding_threads <= 0) {
-      throw std::domain_error(
-          "# of pushing threads must be a positive integer");
+      throw std::domain_error("# of pushing threads must be a positive integer");
     }
   }
 
@@ -260,8 +241,7 @@ int main(int argc, char *argv[]) {
     n_removing_threads = vm["pop_threads"].as<int>();
 
     if (n_removing_threads <= 0) {
-      throw std::domain_error(
-          "# of popping threads must be a positive integer");
+      throw std::domain_error("# of popping threads must be a positive integer");
     }
   }
 
@@ -292,19 +272,15 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  push_distribution.reset(new std::uniform_int_distribution<int>(
-      0, 2 * 1000 * avg_milliseconds_between_pushes));
-  pop_distribution.reset(new std::uniform_int_distribution<int>(
-      0, 2 * 1000 * avg_milliseconds_between_pops));
+  push_distribution.reset(new std::uniform_int_distribution<int>(0, 2 * 1000 * avg_milliseconds_between_pushes));
+  pop_distribution.reset(new std::uniform_int_distribution<int>(0, 2 * 1000 * avg_milliseconds_between_pops));
 
-  TLOG(TLVL_INFO)
-      << n_adding_threads << " thread(s) pushing " << nelements
-      << " elements between them, each thread has an average time of "
-      << avg_milliseconds_between_pushes << " milliseconds between pushes";
-  TLOG(TLVL_INFO)
-      << n_removing_threads << " thread(s) popping " << nelements
-      << " elements between them, each thread has an average time of "
-      << avg_milliseconds_between_pops << " milliseconds between pops";
+  TLOG(TLVL_INFO) << n_adding_threads << " thread(s) pushing " << nelements
+                  << " elements between them, each thread has an average time of " << avg_milliseconds_between_pushes
+                  << " milliseconds between pushes";
+  TLOG(TLVL_INFO) << n_removing_threads << " thread(s) popping " << nelements
+                  << " elements between them, each thread has an average time of " << avg_milliseconds_between_pops
+                  << " milliseconds between pops";
 
 /**
  * \todo Add capacity constructor to Queue interface so that this code section
@@ -343,23 +319,20 @@ int main(int argc, char *argv[]) {
     removers.emplace_back(remove_things);
   }
 
-  for (auto &adder : adders) {
+  for (auto& adder : adders) {
     adder.join();
   }
 
-  for (auto &remover : removers) {
+  for (auto& remover : removers) {
     remover.join();
   }
 
   TLOG(TLVL_INFO) << "Max queue size during running was " << max_queue_size;
   TLOG(TLVL_INFO) << "Final queue size at the end of running is " << queue_size;
-  TLOG(TLVL_INFO) << push_attempts
-                  << " push attempts made: " << successful_pushes
-                  << " successful, " << timeout_pushes << " timeouts, "
-                  << throw_pushes << " exception throws";
-  TLOG(TLVL_INFO) << pop_attempts << " pop attempts made: " << successful_pops
-                  << " successful, " << timeout_pops << " timeouts, "
-                  << throw_pops << " exception throws";
+  TLOG(TLVL_INFO) << push_attempts << " push attempts made: " << successful_pushes << " successful, " << timeout_pushes
+                  << " timeouts, " << throw_pushes << " exception throws";
+  TLOG(TLVL_INFO) << pop_attempts << " pop attempts made: " << successful_pops << " successful, " << timeout_pops
+                  << " timeouts, " << throw_pops << " exception throws";
 
   return 0;
 } // NOLINT

--- a/unittest/DAQModuleThreadHelper_test.cxx
+++ b/unittest/DAQModuleThreadHelper_test.cxx
@@ -20,9 +20,7 @@
 
 namespace {
 
-void
-DoSomething()
-{
+void DoSomething() {
   int nseconds = 5;
   BOOST_TEST_MESSAGE("This function will just sleep for "
                      << nseconds << " second(s) and then return");
@@ -31,44 +29,42 @@ DoSomething()
 
 } // namespace
 
-BOOST_AUTO_TEST_CASE(sanity_checks)
-{
+BOOST_AUTO_TEST_CASE(sanity_checks) {
 
   std::unique_ptr<dunedaq::appfwk::DAQModuleThreadHelper> umth_ptr = nullptr;
 
   auto starttime = std::chrono::steady_clock::now();
   BOOST_REQUIRE_NO_THROW(
-    umth_ptr =
-      std::make_unique<dunedaq::appfwk::DAQModuleThreadHelper>(DoSomething));
+      umth_ptr = std::make_unique<dunedaq::appfwk::DAQModuleThreadHelper>(
+          DoSomething));
   auto construction_time_in_ms =
-    std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::steady_clock::now() - starttime)
-      .count();
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - starttime)
+          .count();
   BOOST_TEST_MESSAGE("Construction time was " << construction_time_in_ms
                                               << " ms");
 
   starttime = std::chrono::steady_clock::now();
   BOOST_REQUIRE_NO_THROW(umth_ptr->start_working_thread_());
   auto start_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::steady_clock::now() - starttime)
-                            .count();
+                              std::chrono::steady_clock::now() - starttime)
+                              .count();
   BOOST_TEST_MESSAGE(
-    "Time to call DAQModuleThreadHelper::start_working_thread_() was "
-    << start_time_in_ms << " ms");
+      "Time to call DAQModuleThreadHelper::start_working_thread_() was "
+      << start_time_in_ms << " ms");
 
   starttime = std::chrono::steady_clock::now();
   BOOST_REQUIRE_NO_THROW(umth_ptr->stop_working_thread_());
   auto stop_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                           std::chrono::steady_clock::now() - starttime)
-                           .count();
+                             std::chrono::steady_clock::now() - starttime)
+                             .count();
   BOOST_TEST_MESSAGE(
-    "Time to call DAQModuleThreadHelper::stop_working_thread_() was "
-    << stop_time_in_ms << " ms");
+      "Time to call DAQModuleThreadHelper::stop_working_thread_() was "
+      << stop_time_in_ms << " ms");
 }
 
 BOOST_AUTO_TEST_CASE(inappropriate_transitions,
-                     *boost::unit_test::depends_on("sanity_checks"))
-{
+                     *boost::unit_test::depends_on("sanity_checks")) {
 
   dunedaq::appfwk::DAQModuleThreadHelper umth(DoSomething);
   BOOST_REQUIRE_THROW(umth.stop_working_thread_(), std::runtime_error);
@@ -83,17 +79,14 @@ BOOST_AUTO_TEST_CASE(inappropriate_transitions,
 // You'll want this to test case to execute last, for reasons that are obvious
 // if you look at its checks
 
-BOOST_AUTO_TEST_CASE(abort_checks,
-                     *boost::unit_test::depends_on("inappropriate_transitions"))
-{
+BOOST_AUTO_TEST_CASE(
+    abort_checks, *boost::unit_test::depends_on("inappropriate_transitions")) {
 
-  {
-    dunedaq::appfwk::DAQModuleThreadHelper umth(DoSomething);
-  }
+  { dunedaq::appfwk::DAQModuleThreadHelper umth(DoSomething); }
   BOOST_TEST(
-    true,
-    "DAQModuleThreadHelper without having start_working_thread_() thread "
-    "called destructs without aborting the program, as expected");
+      true,
+      "DAQModuleThreadHelper without having start_working_thread_() thread "
+      "called destructs without aborting the program, as expected");
 
   // BOOST_TEST_MESSAGE(
   //     "You should *expect* the program to abort in a moment, since we're "

--- a/unittest/DAQModuleThreadHelper_test.cxx
+++ b/unittest/DAQModuleThreadHelper_test.cxx
@@ -20,51 +20,42 @@
 
 namespace {
 
-void DoSomething() {
+void
+DoSomething()
+{
   int nseconds = 5;
-  BOOST_TEST_MESSAGE("This function will just sleep for "
-                     << nseconds << " second(s) and then return");
+  BOOST_TEST_MESSAGE("This function will just sleep for " << nseconds << " second(s) and then return");
   std::this_thread::sleep_for(std::chrono::seconds(nseconds));
 }
 
 } // namespace
 
-BOOST_AUTO_TEST_CASE(sanity_checks) {
+BOOST_AUTO_TEST_CASE(sanity_checks)
+{
 
   std::unique_ptr<dunedaq::appfwk::DAQModuleThreadHelper> umth_ptr = nullptr;
 
   auto starttime = std::chrono::steady_clock::now();
-  BOOST_REQUIRE_NO_THROW(
-      umth_ptr = std::make_unique<dunedaq::appfwk::DAQModuleThreadHelper>(
-          DoSomething));
+  BOOST_REQUIRE_NO_THROW(umth_ptr = std::make_unique<dunedaq::appfwk::DAQModuleThreadHelper>(DoSomething));
   auto construction_time_in_ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - starttime)
-          .count();
-  BOOST_TEST_MESSAGE("Construction time was " << construction_time_in_ms
-                                              << " ms");
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
+  BOOST_TEST_MESSAGE("Construction time was " << construction_time_in_ms << " ms");
 
   starttime = std::chrono::steady_clock::now();
   BOOST_REQUIRE_NO_THROW(umth_ptr->start_working_thread_());
-  auto start_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                              std::chrono::steady_clock::now() - starttime)
-                              .count();
-  BOOST_TEST_MESSAGE(
-      "Time to call DAQModuleThreadHelper::start_working_thread_() was "
-      << start_time_in_ms << " ms");
+  auto start_time_in_ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
+  BOOST_TEST_MESSAGE("Time to call DAQModuleThreadHelper::start_working_thread_() was " << start_time_in_ms << " ms");
 
   starttime = std::chrono::steady_clock::now();
   BOOST_REQUIRE_NO_THROW(umth_ptr->stop_working_thread_());
-  auto stop_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                             std::chrono::steady_clock::now() - starttime)
-                             .count();
-  BOOST_TEST_MESSAGE(
-      "Time to call DAQModuleThreadHelper::stop_working_thread_() was "
-      << stop_time_in_ms << " ms");
+  auto stop_time_in_ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
+  BOOST_TEST_MESSAGE("Time to call DAQModuleThreadHelper::stop_working_thread_() was " << stop_time_in_ms << " ms");
 }
 
-BOOST_AUTO_TEST_CASE(inappropriate_transitions,
-                     *boost::unit_test::depends_on("sanity_checks")) {
+BOOST_AUTO_TEST_CASE(inappropriate_transitions, *boost::unit_test::depends_on("sanity_checks"))
+{
 
   dunedaq::appfwk::DAQModuleThreadHelper umth(DoSomething);
   BOOST_REQUIRE_THROW(umth.stop_working_thread_(), std::runtime_error);
@@ -79,14 +70,15 @@ BOOST_AUTO_TEST_CASE(inappropriate_transitions,
 // You'll want this to test case to execute last, for reasons that are obvious
 // if you look at its checks
 
-BOOST_AUTO_TEST_CASE(
-    abort_checks, *boost::unit_test::depends_on("inappropriate_transitions")) {
+BOOST_AUTO_TEST_CASE(abort_checks, *boost::unit_test::depends_on("inappropriate_transitions"))
+{
 
-  { dunedaq::appfwk::DAQModuleThreadHelper umth(DoSomething); }
-  BOOST_TEST(
-      true,
-      "DAQModuleThreadHelper without having start_working_thread_() thread "
-      "called destructs without aborting the program, as expected");
+  {
+    dunedaq::appfwk::DAQModuleThreadHelper umth(DoSomething);
+  }
+  BOOST_TEST(true,
+             "DAQModuleThreadHelper without having start_working_thread_() thread "
+             "called destructs without aborting the program, as expected");
 
   // BOOST_TEST_MESSAGE(
   //     "You should *expect* the program to abort in a moment, since we're "

--- a/unittest/FanOutDAQModule_test.cxx
+++ b/unittest/FanOutDAQModule_test.cxx
@@ -22,9 +22,11 @@ BOOST_AUTO_TEST_SUITE(FanOutDAQModule_test)
 /**
  * @brief Initializes the QueueRegistry for use by the FanOutDAQModule test
  */
-struct FanOutDAQModuleTestFixture {
+struct FanOutDAQModuleTestFixture
+{
   FanOutDAQModuleTestFixture() {}
-  void setup() {
+  void setup()
+  {
 
     std::map<std::string, QueueConfig> queue_config;
     queue_config["input"].kind = QueueConfig::queue_kind::kStdDeQueue;
@@ -40,13 +42,14 @@ struct FanOutDAQModuleTestFixture {
 
 BOOST_TEST_GLOBAL_FIXTURE(FanOutDAQModuleTestFixture);
 
-BOOST_AUTO_TEST_CASE(Construct) {
+BOOST_AUTO_TEST_CASE(Construct)
+{
   dunedaq::appfwk::FanOutDAQModule<int> foum("test");
 }
 
-BOOST_AUTO_TEST_CASE(Configure) {
-  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum(
-      "test");
+BOOST_AUTO_TEST_CASE(Configure)
+{
+  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum("test");
 
   auto config = R"({"input": "input"})"_json;
   foum.configure(config);
@@ -54,9 +57,9 @@ BOOST_AUTO_TEST_CASE(Configure) {
   foum.execute_command("configure");
 }
 
-BOOST_AUTO_TEST_CASE(NonCopyableTypeTest) {
-  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum(
-      "test");
+BOOST_AUTO_TEST_CASE(NonCopyableTypeTest)
+{
+  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum("test");
 
   nlohmann::json module_config = R"(
         {

--- a/unittest/FanOutDAQModule_test.cxx
+++ b/unittest/FanOutDAQModule_test.cxx
@@ -21,12 +21,10 @@ BOOST_AUTO_TEST_SUITE(FanOutDAQModule_test)
 
 /**
  * @brief Initializes the QueueRegistry for use by the FanOutDAQModule test
-*/
-struct FanOutDAQModuleTestFixture
-{
+ */
+struct FanOutDAQModuleTestFixture {
   FanOutDAQModuleTestFixture() {}
-  void setup()
-  {
+  void setup() {
 
     std::map<std::string, QueueConfig> queue_config;
     queue_config["input"].kind = QueueConfig::queue_kind::kStdDeQueue;
@@ -42,14 +40,13 @@ struct FanOutDAQModuleTestFixture
 
 BOOST_TEST_GLOBAL_FIXTURE(FanOutDAQModuleTestFixture);
 
-BOOST_AUTO_TEST_CASE(Construct)
-{
+BOOST_AUTO_TEST_CASE(Construct) {
   dunedaq::appfwk::FanOutDAQModule<int> foum("test");
 }
 
-BOOST_AUTO_TEST_CASE(Configure)
-{
-  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum("test");
+BOOST_AUTO_TEST_CASE(Configure) {
+  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum(
+      "test");
 
   auto config = R"({"input": "input"})"_json;
   foum.configure(config);
@@ -57,9 +54,9 @@ BOOST_AUTO_TEST_CASE(Configure)
   foum.execute_command("configure");
 }
 
-BOOST_AUTO_TEST_CASE(NonCopyableTypeTest)
-{
-  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum("test");
+BOOST_AUTO_TEST_CASE(NonCopyableTypeTest) {
+  dunedaq::appfwk::FanOutDAQModule<dunedaq::appfwk::NonCopyableType> foum(
+      "test");
 
   nlohmann::json module_config = R"(
         {
@@ -87,7 +84,7 @@ BOOST_AUTO_TEST_CASE(NonCopyableTypeTest)
   foum.execute_command("stop");
 
   BOOST_REQUIRE_EQUAL(outputbuf1.can_pop(), true);
-  dunedaq::appfwk::NonCopyableType res(0) ;
+  dunedaq::appfwk::NonCopyableType res(0);
   outputbuf1.pop(res, queue_timeout);
   BOOST_REQUIRE_EQUAL(res.data, 1);
 

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -20,11 +20,9 @@
 
 namespace {
 
-constexpr int max_testable_capacity =
-    1000000000; ///< The maximum capacity this test will attempt to check
-constexpr double fractional_timeout_tolerance =
-    0.1; ///< The fraction of the timeout which the timing is allowed to be off
-         ///< by
+constexpr int max_testable_capacity = 1000000000;    ///< The maximum capacity this test will attempt to check
+constexpr double fractional_timeout_tolerance = 0.1; ///< The fraction of the timeout which the timing is allowed to be
+                                                     ///< off by
 
 /**
  * @brief Timeout to use for tests
@@ -36,11 +34,9 @@ constexpr auto timeout = std::chrono::milliseconds(1);
 /**
  * @brief Timeout expressed in microseconds
  */
-constexpr auto timeout_in_us =
-    std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
+constexpr auto timeout_in_us = std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
 
-dunedaq::appfwk::StdDeQueue<int>
-    Queue("StdDeQueue"); ///< Queue instance for the test
+dunedaq::appfwk::StdDeQueue<int> Queue("StdDeQueue"); ///< Queue instance for the test
 
 /**
  * \todo StdDeQueue no longer exposes size or capacity methods. This section
@@ -76,7 +72,8 @@ struct CapacityChecker
 // This test case should run first. Make sure all other test cases depend on
 // this.
 
-BOOST_AUTO_TEST_CASE(sanity_checks) {
+BOOST_AUTO_TEST_CASE(sanity_checks)
+{
   Queue.SetSize(10);
 
   BOOST_REQUIRE(!Queue.can_pop());
@@ -86,15 +83,12 @@ BOOST_AUTO_TEST_CASE(sanity_checks) {
   auto push_time = std::chrono::steady_clock::now() - starttime;
 
   if (push_time > timeout) {
-    auto push_time_in_us =
-        std::chrono::duration_cast<std::chrono::microseconds>(push_time)
-            .count();
+    auto push_time_in_us = std::chrono::duration_cast<std::chrono::microseconds>(push_time).count();
 
-    BOOST_TEST_REQUIRE(false, "Test failure: pushing element onto empty Queue "
-                              "resulted in a timeout (function exited after "
-                                  << push_time_in_us
-                                  << " microseconds, timeout is "
-                                  << timeout_in_us << " microseconds)");
+    BOOST_TEST_REQUIRE(false,
+                       "Test failure: pushing element onto empty Queue "
+                       "resulted in a timeout (function exited after "
+                         << push_time_in_us << " microseconds, timeout is " << timeout_in_us << " microseconds)");
   }
 
   BOOST_REQUIRE(Queue.can_pop());
@@ -105,31 +99,30 @@ BOOST_AUTO_TEST_CASE(sanity_checks) {
   auto pop_time = std::chrono::steady_clock::now() - starttime;
 
   if (pop_time > timeout) {
-    auto pop_time_in_us =
-        std::chrono::duration_cast<std::chrono::microseconds>(pop_time).count();
-    BOOST_TEST_REQUIRE(false, "Test failure: popping element off Queue "
-                              "resulted in a timeout (function exited after "
-                                  << pop_time_in_us
-                                  << " microseconds, timeout is "
-                                  << timeout_in_us << " microseconds)");
+    auto pop_time_in_us = std::chrono::duration_cast<std::chrono::microseconds>(pop_time).count();
+    BOOST_TEST_REQUIRE(false,
+                       "Test failure: popping element off Queue "
+                       "resulted in a timeout (function exited after "
+                         << pop_time_in_us << " microseconds, timeout is " << timeout_in_us << " microseconds)");
   }
 
   BOOST_REQUIRE_EQUAL(popped_value, 999);
 }
 
-BOOST_AUTO_TEST_CASE(empty_checks,
-                     *boost::unit_test::depends_on("sanity_checks")) {
+BOOST_AUTO_TEST_CASE(empty_checks, *boost::unit_test::depends_on("sanity_checks"))
+{
 
   try {
     while (Queue.can_pop()) {
       int popped_value;
       if (!Queue.pop(popped_value, timeout)) {
-        BOOST_TEST(false, "False returned in call to StdDeQueue::pop(); unable "
-                          "to empty the Queue");
+        BOOST_TEST(false,
+                   "False returned in call to StdDeQueue::pop(); unable "
+                   "to empty the Queue");
         break;
       }
     }
-  } catch (const std::runtime_error &err) {
+  } catch (const std::runtime_error& err) {
     BOOST_WARN_MESSAGE(true, err.what());
   }
 
@@ -145,10 +138,8 @@ BOOST_AUTO_TEST_CASE(empty_checks,
 
   const double fraction_of_pop_timeout_used = pop_duration / timeout;
 
-  BOOST_CHECK_GT(fraction_of_pop_timeout_used,
-                 1 - fractional_timeout_tolerance);
-  BOOST_CHECK_LT(fraction_of_pop_timeout_used,
-                 1 + fractional_timeout_tolerance);
+  BOOST_CHECK_GT(fraction_of_pop_timeout_used, 1 - fractional_timeout_tolerance);
+  BOOST_CHECK_LT(fraction_of_pop_timeout_used, 1 + fractional_timeout_tolerance);
 }
 
 /**

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -20,8 +20,11 @@
 
 namespace {
 
-constexpr int max_testable_capacity = 1000000000; ///< The maximum capacity this test will attempt to check
-constexpr double fractional_timeout_tolerance = 0.1; ///< The fraction of the timeout which the timing is allowed to be off by
+constexpr int max_testable_capacity =
+    1000000000; ///< The maximum capacity this test will attempt to check
+constexpr double fractional_timeout_tolerance =
+    0.1; ///< The fraction of the timeout which the timing is allowed to be off
+         ///< by
 
 /**
  * @brief Timeout to use for tests
@@ -32,11 +35,12 @@ constexpr double fractional_timeout_tolerance = 0.1; ///< The fraction of the ti
 constexpr auto timeout = std::chrono::milliseconds(1);
 /**
  * @brief Timeout expressed in microseconds
-*/
+ */
 constexpr auto timeout_in_us =
-  std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
+    std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
 
-dunedaq::appfwk::StdDeQueue<int> Queue("StdDeQueue"); ///< Queue instance for the test
+dunedaq::appfwk::StdDeQueue<int>
+    Queue("StdDeQueue"); ///< Queue instance for the test
 
 /**
  * \todo StdDeQueue no longer exposes size or capacity methods. This section
@@ -67,13 +71,12 @@ struct CapacityChecker
 };
 #endif
 
-} // namespace ""
+} // namespace
 
 // This test case should run first. Make sure all other test cases depend on
 // this.
 
-BOOST_AUTO_TEST_CASE(sanity_checks)
-{
+BOOST_AUTO_TEST_CASE(sanity_checks) {
   Queue.SetSize(10);
 
   BOOST_REQUIRE(!Queue.can_pop());
@@ -84,63 +87,62 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
 
   if (push_time > timeout) {
     auto push_time_in_us =
-      std::chrono::duration_cast<std::chrono::microseconds>(push_time).count();
+        std::chrono::duration_cast<std::chrono::microseconds>(push_time)
+            .count();
 
-    BOOST_TEST_REQUIRE(false,
-                       "Test failure: pushing element onto empty Queue "
-                       "resulted in a timeout (function exited after "
-                         << push_time_in_us << " microseconds, timeout is "
-                         << timeout_in_us << " microseconds)");
+    BOOST_TEST_REQUIRE(false, "Test failure: pushing element onto empty Queue "
+                              "resulted in a timeout (function exited after "
+                                  << push_time_in_us
+                                  << " microseconds, timeout is "
+                                  << timeout_in_us << " microseconds)");
   }
 
   BOOST_REQUIRE(Queue.can_pop());
 
   starttime = std::chrono::steady_clock::now();
-  int popped_value ; 
-  Queue.pop( popped_value, timeout);
+  int popped_value;
+  Queue.pop(popped_value, timeout);
   auto pop_time = std::chrono::steady_clock::now() - starttime;
 
   if (pop_time > timeout) {
     auto pop_time_in_us =
-      std::chrono::duration_cast<std::chrono::microseconds>(pop_time).count();
-    BOOST_TEST_REQUIRE(false,
-                       "Test failure: popping element off Queue "
-                       "resulted in a timeout (function exited after "
-                         << pop_time_in_us << " microseconds, timeout is "
-                         << timeout_in_us << " microseconds)");
+        std::chrono::duration_cast<std::chrono::microseconds>(pop_time).count();
+    BOOST_TEST_REQUIRE(false, "Test failure: popping element off Queue "
+                              "resulted in a timeout (function exited after "
+                                  << pop_time_in_us
+                                  << " microseconds, timeout is "
+                                  << timeout_in_us << " microseconds)");
   }
 
   BOOST_REQUIRE_EQUAL(popped_value, 999);
 }
 
 BOOST_AUTO_TEST_CASE(empty_checks,
-                     *boost::unit_test::depends_on("sanity_checks"))
-{
+                     *boost::unit_test::depends_on("sanity_checks")) {
 
   try {
     while (Queue.can_pop()) {
-      int popped_value ; 
-      if ( ! Queue.pop(popped_value, timeout) ) {
-	BOOST_TEST(false,
-		   "False returned in call to StdDeQueue::pop(); unable "
-		   "to empty the Queue");
-	break ;
+      int popped_value;
+      if (!Queue.pop(popped_value, timeout)) {
+        BOOST_TEST(false, "False returned in call to StdDeQueue::pop(); unable "
+                          "to empty the Queue");
+        break;
       }
     }
-  } catch (const std::runtime_error& err) {
+  } catch (const std::runtime_error &err) {
     BOOST_WARN_MESSAGE(true, err.what());
   }
-  
+
   BOOST_REQUIRE(!Queue.can_pop());
-  
+
   // pop off of an empty Queue
 
-  int popped_value ; 
-  
+  int popped_value;
+
   auto starttime = std::chrono::steady_clock::now();
-  BOOST_TEST( ! Queue.pop(popped_value, timeout) ) ; 
+  BOOST_TEST(!Queue.pop(popped_value, timeout));
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
-  
+
   const double fraction_of_pop_timeout_used = pop_duration / timeout;
 
   BOOST_CHECK_GT(fraction_of_pop_timeout_used,


### PR DESCRIPTION
… available in daq-buildtools was used

Literally what happened is I just ran the code through clang-format using the clang format file mentioned in the commit comment. Among other things the appfwk codebase is now compliant with the C++ Style Guide's two formatting requirements, that lines be less than 120 characters and the indents be two spaces (changed from four this morning). 