### PR TITLE
restore copy push for DAQSink

### DIFF
--- a/include/appfwk/DAQSink.hpp
+++ b/include/appfwk/DAQSink.hpp
@@ -41,6 +41,7 @@ public:
 
   explicit DAQSink(const std::string& name);
   void push(T&& element, const duration_type& timeout = duration_type::zero());
+  void push(const T& element, const duration_type& timeout = duration_type::zero());
   bool can_push();
 
 private:
@@ -63,6 +64,13 @@ void
 DAQSink<T>::push(T&& element, const duration_type& timeout)
 {
   queue_->push(std::move(element), timeout);
+}
+
+template<typename T>
+void
+DAQSink<T>::push(const T& element, const duration_type& timeout)
+{
+  queue_->push( T(element), timeout);
 }
 
 template<typename T>

--- a/include/appfwk/FanOutDAQModule.hpp
+++ b/include/appfwk/FanOutDAQModule.hpp
@@ -119,7 +119,7 @@ private:
   {
     for (auto& o : outputQueues_) {
       auto starttime = std::chrono::steady_clock::now();
-      o->push(ValueType(data), queueTimeout_);
+      o->push( data, queueTimeout_);
       auto endtime = std::chrono::steady_clock::now();
       if (std::chrono::duration_cast<decltype(queueTimeout_)>(endtime - starttime) > queueTimeout_) {
         TLOG(TLVL_WARNING) << "Timeout occurred trying to broadcast data to "


### PR DESCRIPTION
The copy push was lost in the code reorganisation process. This pull request restores is. #39  