### PR TITLE
Jcfreeman2/issue34 improved single cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,22 @@
 cmake_minimum_required(VERSION 3.12)
 project(appfwk)
 
-if(EXISTS $ENV{CETLIB_LIB})
- # UPS
-  include_directories($ENV{CETLIB_INC})
-  include_directories($ENV{CETLIB_EXCEPT_INC})
-  find_library(CETLIB NAMES libcetlib.so)
-  find_library(CETLIB_EXCEPT NAMES libcetlib_except.so)
-else()
-	# Spack
-	find_package(cetlib REQUIRED)
-	set(CETLIB cetlib)
-	set(CETLIB_EXCEPT cetlib_except)
-endif()
+find_package(cetlib REQUIRED)
 
 set(DAQ_LIBRARIES_PACKAGE ${CETLIB} ${CETLIB_EXCEPT} appfwk)
 
+##############################################################################
 point_build_to( apps )
 
 
 add_executable(daq_application apps/daq_application.cxx)
 target_link_libraries(daq_application ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE})
 
+##############################################################################
 point_build_to( doc )
 # (No action taken, doc/CMakeLists.txt was empty)
 
+##############################################################################
 point_build_to( include )  
 
 install(DIRECTORY include DESTINATION include)
@@ -35,11 +27,8 @@ set(PATH_DIRS ${CMAKE_CURRENT_BINARY_DIR}/scripts:${CMAKE_CURRENT_BINARY_DIR}/ap
 set(LIB_DIRS ${CMAKE_CURRENT_BINARY_DIR}/src:${CMAKE_CURRENT_BINARY_DIR}/test)
 configure_file(scripts/setupForRunning.sh.in scripts/setupForRunning.sh @ONLY)
 
-
+##############################################################################
 point_build_to( src )
-
-
-file(GLOB source_files src/*.cpp)
 
 add_library(appfwk SHARED src/QueueRegistry.cpp src/DAQProcess.cpp)
 
@@ -62,6 +51,7 @@ MakeDataTypeLibraries(CPPTYPE std::vector<int> PREFIX VectorInt)
 MakeDataTypeLibraries(CPPTYPE std::string PREFIX String)
 MakeDataTypeLibraries(CPPTYPE dunedaq::appfwk::NonCopyableType PREFIX NonCopyableType)
 
+##############################################################################
 point_build_to( test )
 
 add_executable(queue_IO_check test/queue_IO_check.cxx)
@@ -82,6 +72,8 @@ target_link_libraries (producer_consumer_test_app ${DAQ_LIBRARIES_UNIVERSAL_EXE}
 add_executable        (daq_sink_source test/daq_sink_source.cxx)
 target_link_libraries (daq_sink_source ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE})
 
+
+##############################################################################
 point_build_to( unittest )
 
 add_unit_test(StdDeQueue_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,14 +18,7 @@ point_build_to( doc )
 
 ##############################################################################
 point_build_to( include )  
-
-install(DIRECTORY include DESTINATION include)
-
-
-set(SPACK_ROOT $ENV{SPACK_ROOT})
-set(PATH_DIRS ${CMAKE_CURRENT_BINARY_DIR}/scripts:${CMAKE_CURRENT_BINARY_DIR}/apps:${CMAKE_CURRENT_BINARY_DIR}/test)
-set(LIB_DIRS ${CMAKE_CURRENT_BINARY_DIR}/src:${CMAKE_CURRENT_BINARY_DIR}/test)
-configure_file(scripts/setupForRunning.sh.in scripts/setupForRunning.sh @ONLY)
+# (No action taken, though eventually we'll install the public headers out of this area)
 
 ##############################################################################
 point_build_to( src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(appfwk)
 
-
 if(EXISTS $ENV{CETLIB_LIB})
-# UPS
+ # UPS
   include_directories($ENV{CETLIB_INC})
   include_directories($ENV{CETLIB_EXCEPT_INC})
   find_library(CETLIB NAMES libcetlib.so)
@@ -15,19 +14,13 @@ else()
 	set(CETLIB_EXCEPT cetlib_except)
 endif()
 
-function( point_build_to output_dir )
-
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${output_dir} PARENT_SCOPE)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${output_dir} PARENT_SCOPE)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${output_dir} PARENT_SCOPE)
-
-endfunction()
+set(DAQ_LIBRARIES_PACKAGE ${CETLIB} ${CETLIB_EXCEPT} appfwk)
 
 point_build_to( apps )
 
 
 add_executable(daq_application apps/daq_application.cxx)
-target_link_libraries(daq_application appfwk  pthread ers ${CETLIB} ${CETLIB_EXCEPT} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(daq_application ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE})
 
 point_build_to( doc )
 # (No action taken, doc/CMakeLists.txt was empty)
@@ -48,10 +41,11 @@ point_build_to( src )
 
 file(GLOB source_files src/*.cpp)
 
-list(FILTER source_files EXCLUDE REGEX "QueryResponseCommandFacility.cpp")
-add_library(appfwk SHARED ${source_files})
-target_link_libraries(appfwk ${CETLIB} ${CETLIB_EXCEPT})
+add_library(appfwk SHARED src/QueueRegistry.cpp src/DAQProcess.cpp)
 
+set( APPFWK_LIBRARIES ${DAQ_LIBRARIES_PACKAGE} )
+list(REMOVE_ITEM APPFWK_LIBRARIES appfwk)
+target_link_libraries(appfwk ${APPFWK_LIBRARIES})
 
 add_library(appfwk_QueryResponseCommandFacility_duneCommandFacility src/QueryResponseCommandFacility.cpp)
 
@@ -71,39 +65,27 @@ MakeDataTypeLibraries(CPPTYPE dunedaq::appfwk::NonCopyableType PREFIX NonCopyabl
 point_build_to( test )
 
 add_executable(queue_IO_check test/queue_IO_check.cxx)
-target_link_libraries(queue_IO_check pthread ${Boost_PROGRAM_OPTIONS_LIBRARY} )
+target_link_libraries(queue_IO_check ${DAQ_LIBRARIES_UNIVERSAL_EXE} )
 
 
 add_library(appfwk_DebugLoggingDAQModule_duneDAQModule test/DebugLoggingDAQModule.cpp)
 add_library(appfwk_FakeDataConsumerDAQModule_duneDAQModule test/FakeDataConsumerDAQModule.cpp)
 add_library(appfwk_FakeDataProducerDAQModule_duneDAQModule test/FakeDataProducerDAQModule.cpp)
 
-add_executable(echo_test_app test/echo_test_app.cxx)
-target_link_libraries(echo_test_app appfwk appfwk_DebugLoggingDAQModule_duneDAQModule pthread ers  ${CETLIB} ${CETLIB_EXCEPT} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+# Curious to hear people's take on this format style which aligns the target across lines...
+add_executable        (echo_test_app test/echo_test_app.cxx)
+target_link_libraries (echo_test_app ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE} appfwk_DebugLoggingDAQModule_duneDAQModule)
 
-add_executable(producer_consumer_test_app test/producer_consumer_test_app.cxx)
-target_link_libraries(producer_consumer_test_app appfwk appfwk_FakeDataProducerDAQModule_duneDAQModule ers appfwk_FakeDataConsumerDAQModule_duneDAQModule pthread  ${CETLIB} ${CETLIB_EXCEPT} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+add_executable        (producer_consumer_test_app test/producer_consumer_test_app.cxx)
+target_link_libraries (producer_consumer_test_app ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE} appfwk_FakeDataProducerDAQModule_duneDAQModule appfwk_FakeDataConsumerDAQModule_duneDAQModule)
 
-add_executable(daq_sink_source test/daq_sink_source.cxx)
-target_link_libraries(daq_sink_source appfwk pthread ers)
+add_executable        (daq_sink_source test/daq_sink_source.cxx)
+target_link_libraries (daq_sink_source ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE})
 
 point_build_to( unittest )
 
-add_executable(StdDeQueue_test unittest/StdDeQueue_test.cxx)
-add_test(NAME StdDeQueue_test COMMAND StdDeQueue_test)
-
-include_directories(${Boost_INCLUDE_DIRS})
-
-add_executable(FanOutDAQModule_test unittest/FanOutDAQModule_test.cxx)
-target_link_libraries(FanOutDAQModule_test appfwk ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} pthread ers)
-target_compile_definitions(FanOutDAQModule_test PRIVATE "BOOST_TEST_DYN_LINK=1")
-target_include_directories(FanOutDAQModule_test PRIVATE ${Boost_INCLUDE_DIRS})
-add_test(NAME FanOutDAQModule_test COMMAND FanOutDAQModule_test ers)
-
-add_executable(DAQModuleThreadHelper_test unittest/DAQModuleThreadHelper_test.cxx)
-target_link_libraries(DAQModuleThreadHelper_test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} pthread)
-target_compile_definitions(DAQModuleThreadHelper_test PRIVATE "BOOST_TEST_DYN_LINK=1")
-target_include_directories(DAQModuleThreadHelper_test PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/appfwk-base/include)
-add_test(NAME DAQModuleThreadHelper_test COMMAND DAQModuleThreadHelper_test)
+add_unit_test(StdDeQueue_test)
+add_unit_test(FanOutDAQModule_test)
+add_unit_test(DAQModuleThreadHelper_test)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(appfwk)
 
-set(CMAKE_CXX_STANDARD 17)
-
-find_package(TRACE 3.15.0 REQUIRED)
-
-find_package(nlohmann_json 3.2.0)
-if(NOT ${nlohmann_json_FOUND})
-  message("nlohmann_json NOT FOUND! Downloading single-header from GitHub!")
-  file(DOWNLOAD https://github.com/nlohmann/json/raw/develop/single_include/nlohmann/json.hpp nlohmann/json.hpp)
-  include_directories(${CMAKE_BINARY_DIR})
-endif()
-
-
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_NO_BOOST_CMAKE ON)
-set(BUILD_SHARED_LIBS ON)
-find_package(Boost 1.70.0 COMPONENTS unit_test_framework program_options REQUIRED)
-
 
 if(EXISTS $ENV{CETLIB_LIB})
 # UPS
@@ -32,10 +15,6 @@ else()
 	set(CETLIB_EXCEPT cetlib_except)
 endif()
 
-include_directories(${CMAKE_SOURCE_DIR}/appfwk/include)
-
-include_directories(${CMAKE_SOURCE_DIR}/ers)
-
 function( point_build_to output_dir )
 
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${output_dir} PARENT_SCOPE)
@@ -46,7 +25,6 @@ endfunction()
 
 point_build_to( apps )
 
-include_directories(${CMAKE_SOURCE_DIR}/appfwk/include)
 
 add_executable(daq_application apps/daq_application.cxx)
 target_link_libraries(daq_application appfwk  pthread ers ${CETLIB} ${CETLIB_EXCEPT} ${Boost_PROGRAM_OPTIONS_LIBRARY})
@@ -92,9 +70,6 @@ MakeDataTypeLibraries(CPPTYPE dunedaq::appfwk::NonCopyableType PREFIX NonCopyabl
 
 point_build_to( test )
 
-set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost COMPONENTS program_options REQUIRED)
-
 add_executable(queue_IO_check test/queue_IO_check.cxx)
 target_link_libraries(queue_IO_check pthread ${Boost_PROGRAM_OPTIONS_LIBRARY} )
 
@@ -114,18 +89,16 @@ target_link_libraries(daq_sink_source appfwk pthread ers)
 
 point_build_to( unittest )
 
-if(Boost_FOUND)
+add_executable(StdDeQueue_test unittest/StdDeQueue_test.cxx)
+add_test(NAME StdDeQueue_test COMMAND StdDeQueue_test)
 
-    include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
 
-    add_executable(StdDeQueue_test unittest/StdDeQueue_test.cxx)
-    add_test(NAME StdDeQueue_test COMMAND StdDeQueue_test)
-
-    add_executable(FanOutDAQModule_test unittest/FanOutDAQModule_test.cxx)
-    target_link_libraries(FanOutDAQModule_test appfwk ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} pthread ers)
-    target_compile_definitions(FanOutDAQModule_test PRIVATE "BOOST_TEST_DYN_LINK=1")
-    target_include_directories(FanOutDAQModule_test PRIVATE ${Boost_INCLUDE_DIRS})
-    add_test(NAME FanOutDAQModule_test COMMAND FanOutDAQModule_test ers)
+add_executable(FanOutDAQModule_test unittest/FanOutDAQModule_test.cxx)
+target_link_libraries(FanOutDAQModule_test appfwk ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} pthread ers)
+target_compile_definitions(FanOutDAQModule_test PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_include_directories(FanOutDAQModule_test PRIVATE ${Boost_INCLUDE_DIRS})
+add_test(NAME FanOutDAQModule_test COMMAND FanOutDAQModule_test ers)
 
 add_executable(DAQModuleThreadHelper_test unittest/DAQModuleThreadHelper_test.cxx)
 target_link_libraries(DAQModuleThreadHelper_test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} pthread)
@@ -133,5 +106,4 @@ target_compile_definitions(DAQModuleThreadHelper_test PRIVATE "BOOST_TEST_DYN_LI
 target_include_directories(DAQModuleThreadHelper_test PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/appfwk-base/include)
 add_test(NAME DAQModuleThreadHelper_test COMMAND DAQModuleThreadHelper_test)
 
-endif()
 


### PR DESCRIPTION
This pull request, focused on simplifying our CMake build code through DUNE-specific CMake functions and better organization, should be reviewed in tandem with the daq-buildtools pull request "Jcfreeman2/issue3 cmake wrapper functions". You can get set up to test the corresponding two issue branches for these two pull requests by executing the following (lines may continue past your window due to length):
```
curl -O https://raw.githubusercontent.com/DUNE-DAQ/daq-buildtools/jcfreeman2/issue3_cmake_wrapper_functions/bin/quick-start.sh
sed -r -i 's/edits_check=true/edits_check=false/' quick-start.sh
chmod +x quick-start.sh
./quick-start.sh   // The "WARNING" message is expected since you're not on develop

cd daq-buildtools
git checkout jcfreeman2/issue3_cmake_wrapper_functions
cd ..

cd appfwk
git checkout jcfreeman2/issue34_improved_single_cmakelists
cd ..

. source_me_to_build
```
...and what you want to see is that things build cleanly, and your solibs and executables work fine and are in the same place in the build subdirectory as before, etc. 
