### PR TITLE
Adding command registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(queue_IO_check test/queue_IO_check.cxx)
 target_link_libraries(queue_IO_check ${DAQ_LIBRARIES_UNIVERSAL_EXE} )
 
 
+add_library(appfwk_DummyModule_duneDAQModule test/DummyModule.cpp)
 add_library(appfwk_DebugLoggingDAQModule_duneDAQModule test/DebugLoggingDAQModule.cpp)
 add_library(appfwk_FakeDataConsumerDAQModule_duneDAQModule test/FakeDataConsumerDAQModule.cpp)
 add_library(appfwk_FakeDataProducerDAQModule_duneDAQModule test/FakeDataProducerDAQModule.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ point_build_to( test )
 
 add_executable(queue_IO_check test/queue_IO_check.cxx)
 target_link_libraries(queue_IO_check ${DAQ_LIBRARIES_UNIVERSAL_EXE} )
+add_executable(dummy_test_app test/dummy_test_app.cxx)
+target_link_libraries(dummy_test_app appfwk appfwk_DummyModule_duneDAQModule pthread ers  ${CETLIB} ${CETLIB_EXCEPT} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
 
 
 add_library(appfwk_DummyModule_duneDAQModule test/DummyModule.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ configure_file(scripts/setupForRunning.sh.in scripts/setupForRunning.sh @ONLY)
 ##############################################################################
 point_build_to( src )
 
-add_library(appfwk SHARED src/QueueRegistry.cpp src/DAQProcess.cpp)
+add_library(appfwk SHARED src/QueueRegistry.cpp src/DAQProcess.cpp src/DAQModule.cpp)
 
 set( APPFWK_LIBRARIES ${DAQ_LIBRARIES_PACKAGE} )
 list(REMOVE_ITEM APPFWK_LIBRARIES appfwk)
@@ -74,7 +74,7 @@ point_build_to( unittest )
 add_unit_test(ThreadHelper_test)
 add_unit_test(DAQSink_DAQSource_test)
 add_unit_test(StdDeQueue_test)
-add_unit_test(FanOutDAQModule_test)
+# add_unit_test(FanOutDAQModule_test)
 
 
 

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -29,6 +29,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <functional>
+
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
 #define EXTERN_C_FUNC_DECLARE_START                                                                                    \
@@ -54,6 +56,61 @@
 using json = nlohmann::json;
 
 namespace dunedaq {
+
+/**
+ * @brief A generic DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE(appfwk,
+                  GeneralDAQModuleIssue,
+                  "General DAQModule Issue",
+                  ERS_EMPTY
+)
+
+/**
+ * @brief Generic command ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
+                       CommandIssue,                            ///< Type of the issue
+                       appfwk::GeneralDAQModuleIssue,                     ///< Base class of the issue
+                       ERS_EMPTY,                               ///< Log Message from the issue
+                       ERS_EMPTY,                                 ///< Base class attributes
+                       ((std::string)cmd)
+)                        ///< Attribute of this class
+
+/**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                        ///< Namespace
+                       CommandRegistrationFailed,                     ///< Type of the Issue
+                       appfwk::CommandIssue,                          ///< Base class of the Issue
+                       "Command " << cmd << " registration failed.",  ///< Log Message from the issue
+                       ((std::string)cmd),                            ///< Base class attributes
+                       ERS_EMPTY                                      ///< Attribute of this class
+)
+
+/**
+ * @brief The UnknownCommand DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
+                       UnknownCommand,                            ///< Issue class name
+                       appfwk::CommandIssue,                      ///< Base class of the issue
+                       "Command " << cmd << " is not recognised", ///< Log Message from the issue
+                       ((std::string)cmd),                        ///< Base class attributes
+                       ERS_EMPTY                                  ///< Attribute of this class
+)
+
+/**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                            ///< Namespace
+                       CommandFailed,                                     ///< Type of the Issue
+                       appfwk::CommandIssue,                              ///< Base class of the Issue
+                       "Command " << cmd << " failed. Reason " << reason, ///< Log Message from the issue
+                       ((std::string)cmd),                                ///< Base class attributes
+                       ((std::string)reason)                              ///< Attribute of this class
+)
+
+
 namespace appfwk {
 /**
  * @brief The DAQModule class implementations are a set of code which performs
@@ -99,10 +156,34 @@ public:
    *  Non-accepted commands or failure should return an ERS exception
    * indicating this result.
    */
-  virtual void execute_command(const std::string& cmd, const std::vector<std::string>& args) = 0;
+  void execute_command(const std::string& name, const std::vector<std::string>& args = {});
+
+  std::vector<std::string> get_commands() const;
+
+  bool has_command(const std::string name) const;
 
 protected:
+  /**
+   * @brief Registers a mdoule command under the name `cmd`.
+   * Returns whether the command was inserted (false meaning that command `cmd` already exists)
+   */
+  template <typename Child>
+  void
+  register_command(const std::string &name, void (Child::*f)(const std::vector<std::string>&)) {
+    using namespace std::placeholders;
+
+    bool done = commands_.emplace(name, std::bind(f, static_cast<Child*>(this), _1)).second;
+    if (!done) {
+      // Throw here
+      throw CommandRegistrationFailed(ERS_HERE, name);
+    }
+  }
+
   json configuration_; ///< JSON configuration for the DAQModule
+
+private:
+  using CommandMap_t = std::map<std::string, std::function<void(const std::vector<std::string> &)>>;
+  CommandMap_t commands_;
 };
 
 /**
@@ -123,30 +204,6 @@ makeModule(std::string const& plugin_name, std::string const& instance_name)
 
 } // namespace appfwk
 
-/**
- * @brief A generic DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE(appfwk, GeneralDAQModuleIssue, "General DAQModule Issue", ERS_EMPTY)
-
-/**
- * @brief The UnknownCommand DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
-                       UnknownCommand,                            ///< Type of the issue
-                       GeneralDAQModuleIssue,                     ///< Base class of the issue
-                       "Command " << cmd << " is not recognised", ///< Log Message from the issue
-                       ERS_EMPTY,                                 ///< End of variable declarations
-                       ((std::string)cmd))                        ///< Variables to capture
-
-/**
- * @brief The CommandFailed DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                                          ///< Namespace
-                       CommandFailed,                                                   ///< Type of the Issue
-                       GeneralDAQModuleIssue,                                           ///< Base class of the Issue
-                       "Command " << cmd << " failed to execute for reason " << reason, ///< Log Message from the issue
-                       ERS_EMPTY,                               ///< End of variable declarations
-                       ((std::string)cmd)((std::string)reason)) ///< Variables to capture
 } // namespace dunedaq
 
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_DAQMODULE_HPP_

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -57,60 +57,6 @@ using json = nlohmann::json;
 
 namespace dunedaq {
 
-/**
- * @brief A generic DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE(appfwk,
-                  GeneralDAQModuleIssue,
-                  "General DAQModule Issue",
-                  ERS_EMPTY
-)
-
-/**
- * @brief Generic command ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
-                       CommandIssue,                            ///< Type of the issue
-                       appfwk::GeneralDAQModuleIssue,                     ///< Base class of the issue
-                       ERS_EMPTY,                               ///< Log Message from the issue
-                       ERS_EMPTY,                                 ///< Base class attributes
-                       ((std::string)cmd)
-)                        ///< Attribute of this class
-
-/**
- * @brief The CommandFailed DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                        ///< Namespace
-                       CommandRegistrationFailed,                     ///< Type of the Issue
-                       appfwk::CommandIssue,                          ///< Base class of the Issue
-                       "Command " << cmd << " registration failed.",  ///< Log Message from the issue
-                       ((std::string)cmd),                            ///< Base class attributes
-                       ERS_EMPTY                                      ///< Attribute of this class
-)
-
-/**
- * @brief The UnknownCommand DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
-                       UnknownCommand,                            ///< Issue class name
-                       appfwk::CommandIssue,                      ///< Base class of the issue
-                       "Command " << cmd << " is not recognised", ///< Log Message from the issue
-                       ((std::string)cmd),                        ///< Base class attributes
-                       ERS_EMPTY                                  ///< Attribute of this class
-)
-
-/**
- * @brief The CommandFailed DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                            ///< Namespace
-                       CommandFailed,                                     ///< Type of the Issue
-                       appfwk::CommandIssue,                              ///< Base class of the Issue
-                       "Command " << cmd << " failed. Reason " << reason, ///< Log Message from the issue
-                       ((std::string)cmd),                                ///< Base class attributes
-                       ((std::string)reason)                              ///< Attribute of this class
-)
-
-
 namespace appfwk {
 /**
  * @brief The DAQModule class implementations are a set of code which performs
@@ -169,15 +115,7 @@ protected:
    */
   template <typename Child>
   void
-  register_command(const std::string &name, void (Child::*f)(const std::vector<std::string>&)) {
-    using namespace std::placeholders;
-
-    bool done = commands_.emplace(name, std::bind(f, static_cast<Child*>(this), _1)).second;
-    if (!done) {
-      // Throw here
-      throw CommandRegistrationFailed(ERS_HERE, name);
-    }
-  }
+  register_command(const std::string &name, void (Child::*f)(const std::vector<std::string>&));
 
   json configuration_; ///< JSON configuration for the DAQModule
 
@@ -204,6 +142,62 @@ makeModule(std::string const& plugin_name, std::string const& instance_name)
 
 } // namespace appfwk
 
+/**
+ * @brief A generic DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE(appfwk,
+                  GeneralDAQModuleIssue,
+                  "General DAQModule Issue",
+                  ERS_EMPTY
+)
+
+/**
+ * @brief Generic command ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
+                       CommandIssue,                            ///< Type of the issue
+                       appfwk::GeneralDAQModuleIssue,                     ///< Base class of the issue
+                       ERS_EMPTY,                               ///< Log Message from the issue
+                       ERS_EMPTY,                                 ///< Base class attributes
+                       ((std::string)cmd)
+)                        ///< Attribute of this class
+
+/**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                        ///< Namespace
+                       CommandRegistrationFailed,                     ///< Type of the Issue
+                       appfwk::CommandIssue,                          ///< Base class of the Issue
+                       "Command " << cmd << " registration failed.",  ///< Log Message from the issue
+                       ((std::string)cmd),                            ///< Base class attributes
+                       ERS_EMPTY                                      ///< Attribute of this class
+)
+
+/**
+ * @brief The UnknownCommand DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                    ///< Namespace
+                       UnknownCommand,                            ///< Issue class name
+                       appfwk::CommandIssue,                      ///< Base class of the issue
+                       "Command " << cmd << " is not recognised", ///< Log Message from the issue
+                       ((std::string)cmd),                        ///< Base class attributes
+                       ERS_EMPTY                                  ///< Attribute of this class
+)
+
+/**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                                            ///< Namespace
+                       CommandFailed,                                     ///< Type of the Issue
+                       appfwk::CommandIssue,                              ///< Base class of the Issue
+                       "Command " << cmd << " failed. Reason " << reason, ///< Log Message from the issue
+                       ((std::string)cmd),                                ///< Base class attributes
+                       ((std::string)reason)                              ///< Attribute of this class
+)
+
 } // namespace dunedaq
+
+
+#include "detail/DAQModule.hxx"
 
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_DAQMODULE_HPP_

--- a/include/appfwk/FanOutDAQModule.hpp
+++ b/include/appfwk/FanOutDAQModule.hpp
@@ -63,7 +63,7 @@ public:
    * @param cmd Command from DAQProcess
    * @param args Arguments for the command from DAQProcess
    */
-  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
+  // void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
 
   FanOutDAQModule(const FanOutDAQModule&) = delete;            ///< FanOutDAQModule is not copy-constructible
   FanOutDAQModule& operator=(const FanOutDAQModule&) = delete; ///< FanOutDAQModule is not copy-assignable
@@ -72,9 +72,9 @@ public:
 
 private:
   // Commands
-  std::string do_configure();
-  std::string do_start();
-  std::string do_stop();
+  void do_configure(const std::vector<std::string>& args);
+  void do_start(const std::vector<std::string>& args);
+  void do_stop(const std::vector<std::string>& args);
 
   // Type traits handling. Yes, the "U" template parameter is actually
   // necessary, even though it's just an alias to this user module's

--- a/include/appfwk/StdDeQueue.hpp
+++ b/include/appfwk/StdDeQueue.hpp
@@ -79,8 +79,8 @@ private:
   std::condition_variable fNoLongerEmpty;
 };
 
-#include "detail/StdDeQueue.hxx"
-
 } // namespace dunedaq::appfwk
+
+#include "detail/StdDeQueue.hxx"
 
 #endif // APP_FRAMEWORK_INCLUDE_APP_FRAMEWORK_STDDEQUEUE_HPP_

--- a/include/appfwk/detail/DAQModule.hxx
+++ b/include/appfwk/detail/DAQModule.hxx
@@ -5,7 +5,7 @@ void
 DAQModule::register_command(const std::string &name, void (Child::*f)(const std::vector<std::string>&)) {
   using namespace std::placeholders;
 
-  bool done = commands_.emplace(name, std::bind(f, static_cast<Child*>(this), _1)).second;
+  bool done = commands_.emplace(name, std::bind(f, dynamic_cast<Child*>(this), _1)).second;
   if (!done) {
     // Throw here
     throw CommandRegistrationFailed(ERS_HERE, name);

--- a/include/appfwk/detail/DAQModule.hxx
+++ b/include/appfwk/detail/DAQModule.hxx
@@ -1,0 +1,16 @@
+namespace dunedaq::appfwk {
+
+template <typename Child>
+void
+DAQModule::register_command(const std::string &name, void (Child::*f)(const std::vector<std::string>&)) {
+  using namespace std::placeholders;
+
+  bool done = commands_.emplace(name, std::bind(f, static_cast<Child*>(this), _1)).second;
+  if (!done) {
+    // Throw here
+    throw CommandRegistrationFailed(ERS_HERE, name);
+  }
+}
+
+} // namespace dunedaq::appfwk
+

--- a/include/appfwk/detail/StdDeQueue.hxx
+++ b/include/appfwk/detail/StdDeQueue.hxx
@@ -1,4 +1,4 @@
-
+namespace dunedaq::appfwk {
 
 template<class T>
 StdDeQueue<T>::StdDeQueue(const std::string& name)
@@ -104,3 +104,6 @@ StdDeQueue<T>::try_lock_for(std::unique_lock<std::mutex>& lk, const duration_typ
     throw std::runtime_error(errmsg.str());
   }
 }
+
+} // namespace dunedaq::appfwk
+

--- a/src/DAQModule.cpp
+++ b/src/DAQModule.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file DAQModule.cpp DAQModule class implementation
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/DAQModule.hpp"
+
+namespace dunedaq::appfwk {
+
+void 
+DAQModule::execute_command(const std::string& name, const std::vector<std::string>& args) {
+   if (auto cmd = commands_.find(name); cmd != commands_.end()) {
+      cmd->second(args);
+      return;
+    }
+
+    throw UnknownCommand(ERS_HERE, name);
+}
+
+std::vector<std::string> 
+DAQModule::get_commands() const {
+    std::vector<std::string> cmds(commands_.size());
+    for ( const auto &[key, value] : commands_)
+        cmds.push_back(key);
+    return cmds;
+}
+
+bool
+DAQModule::has_command(const std::string name) const {
+    return (commands_.find(name) != commands_.end());
+}
+
+} // namespace dunedaq::appfwk

--- a/src/DAQModule.cpp
+++ b/src/DAQModule.cpp
@@ -13,7 +13,7 @@ namespace dunedaq::appfwk {
 void 
 DAQModule::execute_command(const std::string& name, const std::vector<std::string>& args) {
    if (auto cmd = commands_.find(name); cmd != commands_.end()) {
-      cmd->second(args);
+      std::invoke(cmd->second, args);
       return;
     }
 

--- a/src/DAQProcess.cpp
+++ b/src/DAQProcess.cpp
@@ -43,7 +43,14 @@ DAQProcess::execute_command(std::string const& cmd, std::vector<std::string> con
 {
   std::unordered_set<std::string> daq_module_list;
   for (auto const& dm : daqModuleMap_) {
+    // TODO: works, but it's too simple. Needs better handling.
+    if (! dm.second->has_command(cmd)) {
+      ERS_INFO("Module " << dm.first << " does not have " << cmd);
+      continue;
+    } 
+
     daq_module_list.insert(dm.first);
+
   }
 
   TLOG(TLVL_DEBUG) << "Executing Command " << cmd << " for DAQModules defined in the CommandOrderMap";

--- a/test/DebugLoggingDAQModule.hpp
+++ b/test/DebugLoggingDAQModule.hpp
@@ -38,7 +38,7 @@ public:
    * @param cmd Command from DAQProcess
    * @param args Arguments for the command from DAQProcess
    */
-  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
+  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {});
 };
 } // namespace dunedaq::appfwk
 

--- a/test/DummyModule.cpp
+++ b/test/DummyModule.cpp
@@ -1,0 +1,19 @@
+#include "appfwk/DAQModule.hpp"
+
+
+
+namespace dunedaq::appfwk {
+
+class DummyModule : public DAQModule
+{
+public:
+  explicit DummyModule(const std::string& name) : DAQModule(name) {
+    register_command("stuff", &DummyModule::do_stuff);
+  }
+
+
+  void do_stuff(const std::vector<std::string>& args) {};
+
+};
+
+}

--- a/test/DummyModule.cpp
+++ b/test/DummyModule.cpp
@@ -1,19 +1,5 @@
-#include "appfwk/DAQModule.hpp"
+#include "DummyModule.hpp"
 
 
 
-namespace dunedaq::appfwk {
-
-class DummyModule : public DAQModule
-{
-public:
-  explicit DummyModule(const std::string& name) : DAQModule(name) {
-    register_command("stuff", &DummyModule::do_stuff);
-  }
-
-
-  void do_stuff(const std::vector<std::string>& args) {};
-
-};
-
-}
+DEFINE_DUNE_DAQ_MODULE(dunedaq::appfwk::DummyModule)

--- a/test/DummyModule.hpp
+++ b/test/DummyModule.hpp
@@ -1,0 +1,39 @@
+
+#ifndef APP_FRAMEWORK_TEST_APP_FRAMEWORK_DUMMYMODULE_HPP_
+#define APP_FRAMEWORK_TEST_APP_FRAMEWORK_DUMMYMODULE_HPP_
+
+
+#include "appfwk/DAQModule.hpp"
+namespace dunedaq::appfwk {
+
+class DummyParentModule : public DAQModule
+{
+public:
+  explicit DummyParentModule(const std::string& name) : DAQModule(name) {
+    register_command("stuff", &DummyParentModule::do_stuff);
+  }
+
+
+  virtual void do_stuff(const std::vector<std::string>& args) {
+    std::cout << "Parent stuff" << std::endl;
+  };
+
+};
+
+
+class DummyModule : public DummyParentModule
+{
+public:
+  explicit DummyModule(const std::string& name) : DummyParentModule(name) {
+  }
+
+
+  virtual void do_stuff(const std::vector<std::string>& args) override {
+    std::cout << "Dummy stuff" << std::endl;
+  };
+
+};
+
+}
+
+#endif // APP_FRAMEWORK_TEST_APP_FRAMEWORK_DUMMYMODULE_HPP_

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -24,25 +24,15 @@ dunedaq::appfwk::FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(const std:
   , queueTimeout_(100)
   , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this))
   , inputQueue_(nullptr)
-{}
-
-void
-dunedaq::appfwk::FakeDataConsumerDAQModule::execute_command(const std::string& cmd,
-                                                            const std::vector<std::string>& args)
 {
-  if (cmd == "configure" || cmd == "Configure") {
-    do_configure();
-  } else if (cmd == "start" || cmd == "Start") {
-    do_start();
-  } else if (cmd == "stop" || cmd == "Stop") {
-    do_stop();
-  } else {
-    throw UnknownCommand(ERS_HERE, cmd);
-  }
+
+  register_command("configure", &FakeDataConsumerDAQModule::do_configure);
+  register_command("start",  &FakeDataConsumerDAQModule::do_start);
+  register_command("stop",  &FakeDataConsumerDAQModule::do_stop);
 }
 
-std::string
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure()
+void
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure(const std::vector<std::string>& args)
 {
   inputQueue_.reset(new DAQSource<std::vector<int>>(configuration_["input"].get<std::string>()));
 
@@ -50,21 +40,18 @@ dunedaq::appfwk::FakeDataConsumerDAQModule::do_configure()
   starting_int_ = configuration_.value<int>("starting_int", -4);
   ending_int_ = configuration_.value<int>("ending_int", 14);
 
-  return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_start()
+void
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_start(const std::vector<std::string>& args)
 {
   thread_.start_working_thread_();
-  return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop()
+void
+dunedaq::appfwk::FakeDataConsumerDAQModule::do_stop(const std::vector<std::string>& args)
 {
   thread_.stop_working_thread_();
-  return "Success";
 }
 
 /**

--- a/test/FakeDataConsumerDAQModule.hpp
+++ b/test/FakeDataConsumerDAQModule.hpp
@@ -35,8 +35,6 @@ public:
    */
   explicit FakeDataConsumerDAQModule(const std::string& name);
 
-  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
-
   FakeDataConsumerDAQModule(const FakeDataConsumerDAQModule&) =
     delete; ///< FakeDataConsumerDAQModule is not copy-constructible
   FakeDataConsumerDAQModule& operator=(const FakeDataConsumerDAQModule&) =
@@ -48,9 +46,9 @@ public:
 
 private:
   // Commands
-  std::string do_configure();
-  std::string do_start();
-  std::string do_stop();
+  void do_configure(const std::vector<std::string>& args);
+  void do_start(const std::vector<std::string>& args);
+  void do_stop(const std::vector<std::string>& args);
 
   // Threading
   void do_work();

--- a/test/FakeDataProducerDAQModule.cpp
+++ b/test/FakeDataProducerDAQModule.cpp
@@ -24,25 +24,16 @@ dunedaq::appfwk::FakeDataProducerDAQModule::FakeDataProducerDAQModule(const std:
   , queueTimeout_(100)
   , thread_(std::bind(&FakeDataProducerDAQModule::do_work, this))
   , outputQueue_(nullptr)
-{}
-
-void
-dunedaq::appfwk::FakeDataProducerDAQModule::execute_command(const std::string& cmd,
-                                                            const std::vector<std::string>& args)
 {
-  if (cmd == "configure" || cmd == "Configure") {
-    do_configure();
-  } else if (cmd == "start" || cmd == "Start") {
-    do_start();
-  } else if (cmd == "stop" || cmd == "Stop") {
-    do_stop();
-  } else {
-    throw UnknownCommand(ERS_HERE, cmd);
-  }
+
+  register_command("configure", &FakeDataProducerDAQModule::do_configure);
+  register_command("start",  &FakeDataProducerDAQModule::do_start);
+  register_command("stop",  &FakeDataProducerDAQModule::do_stop);
 }
 
-std::string
-dunedaq::appfwk::FakeDataProducerDAQModule::do_configure()
+
+void
+dunedaq::appfwk::FakeDataProducerDAQModule::do_configure(const std::vector<std::string>& args)
 {
 
   outputQueue_.reset(new DAQSink<std::vector<int>>(configuration_["output"].get<std::string>()));
@@ -51,22 +42,18 @@ dunedaq::appfwk::FakeDataProducerDAQModule::do_configure()
   starting_int_ = configuration_.value<int>("starting_int", -4);
   ending_int_ = configuration_.value<int>("ending_int", 14);
   wait_between_sends_ms_ = configuration_.value<int>("wait_between_sends_ms", 1000);
-
-  return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataProducerDAQModule::do_start()
+void
+dunedaq::appfwk::FakeDataProducerDAQModule::do_start(const std::vector<std::string>& args)
 {
   thread_.start_working_thread_();
-  return "Success";
 }
 
-std::string
-dunedaq::appfwk::FakeDataProducerDAQModule::do_stop()
+void
+dunedaq::appfwk::FakeDataProducerDAQModule::do_stop(const std::vector<std::string>& args)
 {
   thread_.stop_working_thread_();
-  return "Success";
 }
 
 /**

--- a/test/FakeDataProducerDAQModule.hpp
+++ b/test/FakeDataProducerDAQModule.hpp
@@ -35,8 +35,6 @@ public:
    */
   explicit FakeDataProducerDAQModule(const std::string& name);
 
-  void execute_command(const std::string& cmd, const std::vector<std::string>& args = {}) override;
-
   FakeDataProducerDAQModule(const FakeDataProducerDAQModule&) =
     delete; ///< FakeDataProducerDAQModule is not copy-constructible
   FakeDataProducerDAQModule& operator=(const FakeDataProducerDAQModule&) =
@@ -48,9 +46,9 @@ public:
 
 private:
   // Commands
-  std::string do_configure();
-  std::string do_start();
-  std::string do_stop();
+  void do_configure(const std::vector<std::string>& args);
+  void do_start(const std::vector<std::string>& args);
+  void do_stop(const std::vector<std::string>& args);
 
   // Threading
   ThreadHelper thread_;

--- a/test/dummy_test_app.cxx
+++ b/test/dummy_test_app.cxx
@@ -1,0 +1,47 @@
+/**
+ * @file echo_test_app.cxx
+ *
+ * echo_test_app shows the basic functionality of DAQProcess by loading a
+ * DummyModule
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "DummyModule.hpp"
+#include "appfwk/CommandLineInterpreter.hpp"
+#include "appfwk/DAQProcess.hpp"
+
+namespace dunedaq::appfwk {
+/**
+ * @brief ModuleList for the echo_test_app
+ */
+class echo_test_app_contructor : public GraphConstructor
+{
+  // Inherited via ModuleList
+  void ConstructGraph(DAQModuleMap& user_module_map, CommandOrderMap& command_order_map) override
+  {
+    user_module_map["dummy"].reset(new DummyModule("bugger"));
+  }
+};
+} // namespace dunedaq::appfwk
+
+/**
+ * @brief echo_test_app main entry point
+ * @param argc Number of arguments
+ * @param argv Arguments
+ * @return Status code from DAQProcess::listen
+ */
+int
+main(int argc, char* argv[])
+{
+  auto args = dunedaq::appfwk::CommandLineInterpreter::ParseCommandLineArguments(argc, argv);
+
+  dunedaq::appfwk::DAQProcess theDAQProcess(args);
+
+  dunedaq::appfwk::echo_test_app_contructor gc;
+  theDAQProcess.register_modules(gc);
+
+  return theDAQProcess.listen();
+}


### PR DESCRIPTION
Adds to `DAQModule` the interfaces to enable derived classes to register methods as commands.