### PR TITLE
Update ThreadHelper to pass the running_flag to the invoked function,…

### DIFF
--- a/include/appfwk/FanOutDAQModule.hpp
+++ b/include/appfwk/FanOutDAQModule.hpp
@@ -116,7 +116,7 @@ private:
   }
 
   // Threading
-  void do_work();
+  void do_work(std::atomic<bool>&);
   ThreadHelper thread_;
 
   // Configuration

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -25,7 +25,7 @@ namespace dunedaq::appfwk {
 
 FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(const std::string& name)
   : DAQModule(name)
-  , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this))
+  , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this, std::placeholders::_1))
   , queueTimeout_(100)
   , inputQueue_(nullptr)
 {
@@ -53,13 +53,13 @@ FakeDataConsumerDAQModule::do_configure([[maybe_unused]] const std::vector<std::
 void
 FakeDataConsumerDAQModule::do_start([[maybe_unused]] const std::vector<std::string>& args)
 {
-  thread_.start_working_thread_();
+  thread_.start_working_thread();
 }
 
 void
 FakeDataConsumerDAQModule::do_stop([[maybe_unused]] const std::vector<std::string>& args)
 {
-  thread_.stop_working_thread_();
+  thread_.stop_working_thread();
 }
 
 /**
@@ -83,7 +83,7 @@ operator<<(std::ostream& t, std::vector<int> ints)
 }
 
 void
-FakeDataConsumerDAQModule::do_work()
+FakeDataConsumerDAQModule::do_work(std::atomic<bool>& running_flag)
 {
   int current_int = starting_int_;
   int counter = 0;
@@ -91,7 +91,7 @@ FakeDataConsumerDAQModule::do_work()
   std::vector<int> vec;
   std::ostringstream oss;
 
-  while (thread_.thread_running()) {
+  while (running_flag.load()) {
     if (inputQueue_->can_pop()) {
 
       TLOG(TLVL_TRACE) << get_name() << ": Going to receive data from inputQueue";

--- a/test/FakeDataConsumerDAQModule.hpp
+++ b/test/FakeDataConsumerDAQModule.hpp
@@ -56,7 +56,7 @@ private:
   void do_stop(const std::vector<std::string>& args);
 
   // Threading
-  void do_work();
+  void do_work(std::atomic<bool>& running_flag);
   ThreadHelper thread_;
 
   // Configuration (for validation)

--- a/test/FakeDataProducerDAQModule.cpp
+++ b/test/FakeDataProducerDAQModule.cpp
@@ -24,7 +24,7 @@ namespace appfwk {
 
 FakeDataProducerDAQModule::FakeDataProducerDAQModule(const std::string& name)
   : DAQModule(name)
-  , thread_(std::bind(&FakeDataProducerDAQModule::do_work, this))
+  , thread_(std::bind(&FakeDataProducerDAQModule::do_work, this, std::placeholders::_1))
   , outputQueue_(nullptr)
   , queueTimeout_(100)
 {
@@ -50,13 +50,13 @@ FakeDataProducerDAQModule::do_configure([[maybe_unused]] const std::vector<std::
 void
 FakeDataProducerDAQModule::do_start([[maybe_unused]] const std::vector<std::string>& args)
 {
-  thread_.start_working_thread_();
+  thread_.start_working_thread();
 }
 
 void
 FakeDataProducerDAQModule::do_stop([[maybe_unused]] const std::vector<std::string>& args)
 {
-  thread_.stop_working_thread_();
+  thread_.stop_working_thread();
 }
 
 /**
@@ -80,13 +80,13 @@ operator<<(std::ostream& t, std::vector<int> ints)
 }
 
 void
-FakeDataProducerDAQModule::do_work()
+FakeDataProducerDAQModule::do_work(std::atomic<bool>& running_flag)
 {
   int current_int = starting_int_;
   size_t counter = 0;
   std::ostringstream oss;
 
-  while (thread_.thread_running()) {
+  while (running_flag.load()) {
     TLOG(TLVL_TRACE) << get_name() << ": Creating output vector";
     std::vector<int> output(nIntsPerVector_);
 

--- a/test/FakeDataProducerDAQModule.hpp
+++ b/test/FakeDataProducerDAQModule.hpp
@@ -54,7 +54,7 @@ private:
 
   // Threading
   ThreadHelper thread_;
-  void do_work();
+  void do_work(std::atomic<bool>& running_flag);
 
   // Configuration
   std::unique_ptr<DAQSink<std::vector<int>>> outputQueue_;

--- a/unittest/ThreadHelper_test.cxx
+++ b/unittest/ThreadHelper_test.cxx
@@ -21,7 +21,7 @@
 namespace {
 
 void
-DoSomething()
+DoSomething(std::atomic<bool>&)
 {
   int nseconds = 5;
   BOOST_TEST_MESSAGE("This function will just sleep for " << nseconds << " second(s) and then return");
@@ -42,13 +42,13 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
   BOOST_TEST_MESSAGE("Construction time was " << construction_time_in_ms << " ms");
 
   starttime = std::chrono::steady_clock::now();
-  BOOST_REQUIRE_NO_THROW(umth_ptr->start_working_thread_());
+  BOOST_REQUIRE_NO_THROW(umth_ptr->start_working_thread());
   auto start_time_in_ms =
     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
   BOOST_TEST_MESSAGE("Time to call ThreadHelper::start_working_thread_() was " << start_time_in_ms << " ms");
 
   starttime = std::chrono::steady_clock::now();
-  BOOST_REQUIRE_NO_THROW(umth_ptr->stop_working_thread_());
+  BOOST_REQUIRE_NO_THROW(umth_ptr->stop_working_thread());
   auto stop_time_in_ms =
     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
   BOOST_TEST_MESSAGE("Time to call ThreadHelper::stop_working_thread_() was " << stop_time_in_ms << " ms");
@@ -58,13 +58,13 @@ BOOST_AUTO_TEST_CASE(inappropriate_transitions, *boost::unit_test::depends_on("s
 {
 
   dunedaq::appfwk::ThreadHelper umth(DoSomething);
-  BOOST_REQUIRE_THROW(umth.stop_working_thread_(), dunedaq::appfwk::ThreadingIssue);
+  BOOST_REQUIRE_THROW(umth.stop_working_thread(), dunedaq::appfwk::ThreadingIssue);
 
-  umth.start_working_thread_();
+  umth.start_working_thread();
 
-  BOOST_REQUIRE_THROW(umth.start_working_thread_(), dunedaq::appfwk::ThreadingIssue);
+  BOOST_REQUIRE_THROW(umth.start_working_thread(), dunedaq::appfwk::ThreadingIssue);
 
-  umth.stop_working_thread_();
+  umth.stop_working_thread();
 }
 
 // You'll want this to test case to execute last, for reasons that are obvious


### PR DESCRIPTION
… so the function doesn't need to know anything about the enclosing scope.

Also removes trailing underscores from the start and stop functions