### PR TITLE
Fix the StdDeQueue_test

### DIFF
--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(empty_checks)
   BOOST_TEST(!Queue.pop(popped_value, timeout));
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
 
-  const double fraction_of_pop_timeout_used = pop_duration / timeout;
+  const double fraction_of_pop_timeout_used = pop_duration / std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
 
   BOOST_CHECK_GT(fraction_of_pop_timeout_used, 1 - fractional_timeout_tolerance);
   BOOST_CHECK_LT(fraction_of_pop_timeout_used, 1 + fractional_timeout_tolerance);


### PR DESCRIPTION
Make sure that the fractional timeout check is done in the smallest available time units (so that integer division doesn't come into play).