### PR TITLE
JCF: Issue #67: put capacity in the queue's constructor

### DIFF
--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -48,7 +48,7 @@ public:
     for (auto& queue : config_["queues"].items()) {
       QueueConfig qc;
       qc.kind = qc.stoqk(queue.value()["kind"].get<std::string>());
-      qc.size = queue.value()["size"].get<size_t>();
+      qc.capacity = queue.value()["capacity"].get<size_t>();
       queue_configuration[queue.key()] = qc;
     }
 

--- a/include/appfwk/FollyQueue.hpp
+++ b/include/appfwk/FollyQueue.hpp
@@ -31,10 +31,9 @@ public:
   using value_type = T;
   using duration_type = typename Queue<T>::duration_type;
 
-  explicit FollyQueue(const std::string& name)
-    : Queue<T>(name),
-      fMaxSize(0),
-      fQueue(fMaxSize)
+  explicit FollyQueue(const std::string& name, size_t capacity)
+    : Queue<T>(name, capacity),
+      fQueue(this->GetCapacity())
   {}
 
   bool can_pop() const noexcept override { return !fQueue.empty(); }
@@ -45,7 +44,7 @@ public:
 
   bool can_push() const noexcept override
   {
-    return fQueue.size()<fMaxSize;
+    return fQueue.size()<this->GetCapacity();
   }
 
   void push(value_type&& t, const duration_type& dur)  override
@@ -57,12 +56,6 @@ public:
     }
   }
 
-  /**
-   * @brief Set the size of the FollyQueue
-   * @param sz Maximum size for the FollyQueue
-  */
-  void SetSize(size_t sz) { fMaxSize = sz; fQueue.reset_capacity(fMaxSize); }
-
    
   // Delete the copy and move operations
   FollyQueue(const FollyQueue&) = delete;
@@ -71,7 +64,6 @@ public:
   FollyQueue& operator=(FollyQueue&&) = delete;
 
 private:
-  size_t fMaxSize;
   FollyQueueType<T, false> fQueue;
 };
 

--- a/include/appfwk/Queue.hpp
+++ b/include/appfwk/Queue.hpp
@@ -45,8 +45,9 @@ public:
    * @brief Queue Constructor
    * @param name Name of the Queue instance
    */
-  explicit Queue(const std::string& name)
-    : NamedObject(name)
+  explicit Queue(const std::string& name, size_t capacity)
+    : NamedObject(name),
+      capacity_(capacity)
   {}
 
   /**
@@ -87,11 +88,16 @@ public:
    */
   virtual bool can_pop() const noexcept = 0;
 
+protected:
+  size_t GetCapacity() const { return capacity_; }
+
 private:
   Queue(const Queue&) = delete;
   Queue& operator=(const Queue&) = delete;
   Queue(Queue&&) = default;
   Queue& operator=(Queue&&) = default;
+
+  size_t capacity_;
 };
 
 } // namespace appfwk

--- a/include/appfwk/QueueRegistry.hpp
+++ b/include/appfwk/QueueRegistry.hpp
@@ -47,7 +47,7 @@ struct QueueConfig
 
   QueueConfig::queue_kind kind = queue_kind::kUnknown; ///< The kind of Queue represented by this
                                                        ///< QueueConfig
-  size_t size = 0;                                     ///< The size of the queue
+  size_t capacity = 0;                                     ///< The maximum size of the queue
 };
 
 /**

--- a/include/appfwk/StdDeQueue.hpp
+++ b/include/appfwk/StdDeQueue.hpp
@@ -45,12 +45,12 @@ public:
    * @brief StdDeQueue Constructor
    * @param name Name of this StdDeQueue instance
    */
-  explicit StdDeQueue(const std::string& name);
+  explicit StdDeQueue(const std::string& name, size_t capacity);
 
   bool can_pop() const noexcept override { return fSize.load() > 0; }
   bool pop(value_type& val, const duration_type&) override; // Throws std::runtime_error if a timeout occurs
 
-  bool can_push() const noexcept override { return fSize.load() < fMaxSize; }
+  bool can_push() const noexcept override { return fSize.load() < this->GetCapacity(); }
   void push(value_type&&, const duration_type&) override; // Throws std::runtime_error if a timeout occurs
 
   // Delete the copy and move operations since various member data instances
@@ -61,16 +61,9 @@ public:
   StdDeQueue(StdDeQueue&&) = delete;                 ///< StdDeQueue is not move-constructible
   StdDeQueue& operator=(StdDeQueue&&) = delete;      ///< StdDeQueue is not move-assignable
 
-  /**
-   * @brief Set the size of the StdDeQueue
-   * @param sz Maximum size for the StdDeQueue
-   */
-  void SetSize(size_t sz) { fMaxSize = sz; }
 
 private:
   void try_lock_for(std::unique_lock<std::mutex>&, const duration_type&);
-
-  size_t fMaxSize;
 
   std::deque<value_type> fDeque;
   std::atomic<size_t> fSize = 0;

--- a/include/appfwk/detail/QueueRegistry.hxx
+++ b/include/appfwk/detail/QueueRegistry.hxx
@@ -59,16 +59,13 @@ QueueRegistry::create_queue(std::string name, const QueueConfig& config)
   std::shared_ptr<NamedObject> queue;
   switch (config.kind) {
     case QueueConfig::kStdDeQueue:
-      queue = std::make_shared<StdDeQueue<T>>(name);
-      std::dynamic_pointer_cast<StdDeQueue<T>>(queue)->SetSize(config.size);
+      queue = std::make_shared<StdDeQueue<T>>(name, config.capacity);
       break;
     case QueueConfig::kFollySPSCQueue :
-      queue = std::make_shared<FollySPSCQueue<T>>(name);
-      std::dynamic_pointer_cast<FollySPSCQueue<T>>(queue)->SetSize(config.size);
+      queue = std::make_shared<FollySPSCQueue<T>>(name, config.capacity);
       break;
     case QueueConfig::kFollyMPMCQueue :
-      queue = std::make_shared<FollyMPMCQueue<T>>(name);
-      std::dynamic_pointer_cast<FollyMPMCQueue<T>>(queue)->SetSize(config.size);
+      queue = std::make_shared<FollyMPMCQueue<T>>(name, config.capacity);
       break;
 
     default:

--- a/include/appfwk/detail/StdDeQueue.hxx
+++ b/include/appfwk/detail/StdDeQueue.hxx
@@ -4,12 +4,13 @@
 namespace dunedaq::appfwk {
 
 template<class T>
-StdDeQueue<T>::StdDeQueue(const std::string& name)
-  : Queue<T>(name)
-  , fMaxSize(0)
+StdDeQueue<T>::StdDeQueue(const std::string& name, size_t capacity)
+  : Queue<T>(name, capacity)
   , fDeque()
   , fSize(0)
-{}
+{
+  assert(fDeque.max_size() > this->GetCapacity());
+}
 
 template<class T>
 void

--- a/test/producer_consumer_dynamic_test.json
+++ b/test/producer_consumer_dynamic_test.json
@@ -22,7 +22,7 @@
       "user_module_type": "VectorIntFanOutDAQModule",
       "input": "producerToFanOut",
       "outputs": [ "fanOutToConsumer1", "fanOutToConsumer2" ],
-      "fanout_mode": "RoundRobin"
+      "fanout_mode": "round_robin"
     },
     "consumer1": {
       "user_module_type": "FakeDataConsumerDAQModule",

--- a/test/producer_consumer_dynamic_test.json
+++ b/test/producer_consumer_dynamic_test.json
@@ -1,15 +1,15 @@
 {
   "queues": {
     "producerToFanOut": {
-      "size": 10,
+      "capacity": 10,
       "kind": "StdDeQueue"
     },
     "fanOutToConsumer1": {
-      "size": 5,
+      "capacity": 5,
       "kind": "StdDeQueue"
     },
     "fanOutToConsumer2": {
-      "size": 5,
+      "capacity": 5,
       "kind": "StdDeQueue"
     }
   },

--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -230,16 +230,13 @@ main(int argc, char* argv[])
   size_t capacity=vm["capacity"].as<int>();
 
   if (queue_type == "StdDeQueue") {
-    queue.reset(new dunedaq::appfwk::StdDeQueue<int>("StdDeQueue"));
-    dynamic_cast<dunedaq::appfwk::StdDeQueue<int>*>(queue.get())->SetSize(capacity);
+    queue.reset(new dunedaq::appfwk::StdDeQueue<int>("StdDeQueue", capacity));
   }
     else if (queue_type == "FollySPSCQueue") {
-    queue.reset(new dunedaq::appfwk::FollySPSCQueue<int>("FollySPSCQueue"));
-    dynamic_cast<dunedaq::appfwk::FollySPSCQueue<int>*>(queue.get())->SetSize(capacity);
+      queue.reset(new dunedaq::appfwk::FollySPSCQueue<int>("FollySPSCQueue", capacity));
   }
     else if (queue_type == "FollyMPMCQueue") {
-    queue.reset(new dunedaq::appfwk::FollyMPMCQueue<int>("FollyMPMCQueue"));
-    dynamic_cast<dunedaq::appfwk::FollyMPMCQueue<int>*>(queue.get())->SetSize(capacity);
+      queue.reset(new dunedaq::appfwk::FollyMPMCQueue<int>("FollyMPMCQueue", capacity));
   } else {
     TLOG(TLVL_ERROR) << "Unknown queue type \"" << queue_type << "\" requested for testing";
     return 1;

--- a/unittest/FanOutDAQModule_test.cxx
+++ b/unittest/FanOutDAQModule_test.cxx
@@ -30,11 +30,11 @@ struct FanOutDAQModuleTestFixture
 
     std::map<std::string, QueueConfig> queue_config;
     queue_config["input"].kind = QueueConfig::queue_kind::kStdDeQueue;
-    queue_config["input"].size = 10;
+    queue_config["input"].capacity = 10;
     queue_config["output1"].kind = QueueConfig::queue_kind::kStdDeQueue;
-    queue_config["output1"].size = 5;
+    queue_config["output1"].capacity = 5;
     queue_config["output2"].kind = QueueConfig::queue_kind::kStdDeQueue;
-    queue_config["output2"].size = 5;
+    queue_config["output2"].capacity = 5;
 
     QueueRegistry::get().configure(queue_config);
   }

--- a/unittest/FollyQueue_test.cxx
+++ b/unittest/FollyQueue_test.cxx
@@ -36,7 +36,7 @@ constexpr auto timeout = std::chrono::milliseconds(1);
 constexpr auto timeout_in_us =
   std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
 
-dunedaq::appfwk::FollySPSCQueue<int> Queue("FollyQueue"); ///< Queue instance for the test
+  dunedaq::appfwk::FollySPSCQueue<int> Queue("FollyQueue", 10); ///< Queue instance for the test
 
 } // namespace ""
 
@@ -45,8 +45,6 @@ dunedaq::appfwk::FollySPSCQueue<int> Queue("FollyQueue"); ///< Queue instance fo
 
 BOOST_AUTO_TEST_CASE(sanity_checks)
 {
-  Queue.SetSize(10);
-
   BOOST_REQUIRE(!Queue.can_pop());
 
   auto starttime = std::chrono::steady_clock::now();

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -38,7 +38,7 @@ constexpr auto timeout = std::chrono::milliseconds(2);
  */
 constexpr auto timeout_in_us = std::chrono::duration_cast<std::chrono::microseconds>(timeout).count();
 
-dunedaq::appfwk::StdDeQueue<int> Queue("StdDeQueue"); ///< Queue instance for the test
+  dunedaq::appfwk::StdDeQueue<int> Queue("StdDeQueue", 10); ///< Queue instance for the test
 } // namespace ""
 
 // This test case should run first. Make sure all other test cases depend on
@@ -46,7 +46,6 @@ dunedaq::appfwk::StdDeQueue<int> Queue("StdDeQueue"); ///< Queue instance for th
 
 BOOST_AUTO_TEST_CASE(sanity_checks)
 {
-  Queue.SetSize(10);
 
   BOOST_REQUIRE(!Queue.can_pop());
 
@@ -103,7 +102,9 @@ BOOST_AUTO_TEST_CASE(empty_checks)
   BOOST_TEST(!Queue.pop(popped_value, timeout));
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
 
-  const double fraction_of_pop_timeout_used = pop_duration / std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
+  const double fraction_of_pop_timeout_used = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(pop_duration).count())/std::chrono::duration_cast<std::chrono::nanoseconds>(timeout).count();
+
+  BOOST_TEST_MESSAGE("Attempted pop_duration divided by timeout is " << fraction_of_pop_timeout_used);
 
   BOOST_CHECK_GT(fraction_of_pop_timeout_used, 1 - fractional_timeout_tolerance);
   BOOST_CHECK_LT(fraction_of_pop_timeout_used, 1 + fractional_timeout_tolerance);


### PR DESCRIPTION
As discussed at the meeting this morning, I've made capacity an argument to the constructor of the Queue interface. Notice I made a couple of choices: there's no SetCapacity function, and the GetCapacity function is protected. This is me erring on the side of exposing as little interface as possible. I've also changed variable names throughout the code which were using "size" in the sense of "the maximum number of elements the queue can hold" rather than in the sense of "the current number of elements the queue holds"; this usage is more in line with the STL's usage of these words. 
