### PR TITLE
Convert pop() method to throw an exception rather than return a boolean

### DIFF
--- a/include/appfwk/DAQSource.hpp
+++ b/include/appfwk/DAQSource.hpp
@@ -38,7 +38,7 @@ public:
   using duration_type = std::chrono::milliseconds;
 
   explicit DAQSource(const std::string& name);
-  bool pop(T&, const duration_type& timeout = duration_type::zero());
+  void pop(T&, const duration_type& timeout = duration_type::zero());
   bool can_pop();
 
 private:
@@ -57,10 +57,10 @@ DAQSource<T>::DAQSource(const std::string& name)
 }
 
 template<typename T>
-bool
+void
 DAQSource<T>::pop(T& val, const duration_type& timeout)
 {
-  return queue_->pop(val, timeout);
+  queue_->pop(val, timeout);
 }
 
 template<typename T>

--- a/include/appfwk/FollyQueue.hpp
+++ b/include/appfwk/FollyQueue.hpp
@@ -37,9 +37,13 @@ public:
   {}
 
   bool can_pop() const noexcept override { return !fQueue.empty(); }
-  bool pop( value_type & val, const duration_type& dur) override
+  void pop( value_type & val, const duration_type& dur) override
   {
-    return fQueue.try_dequeue_for(val, dur);
+    if (!fQueue.try_dequeue_for(val, dur))
+    {
+      throw QueueTimeoutExpired(
+        ERS_HERE, NamedObject::get_name(), "pop", std::chrono::duration_cast<std::chrono::milliseconds>(dur).count());
+    }
   }
 
   bool can_push() const noexcept override

--- a/include/appfwk/Queue.hpp
+++ b/include/appfwk/Queue.hpp
@@ -71,14 +71,14 @@ public:
 
   /**
    * @brief Pop the first value off of the queue
+   * @param val Reference to the value that is popped from the queue
    * @param timeout Timeout for the pop operation
-   * @return Value popped from the Queue
    *
    * This is a pure virtual function
    * If pop takes longer than the timeout, implementations should throw an
    * exception
    */
-  virtual bool pop(T& val, const duration_type& timeout) = 0;
+  virtual void pop(T& val, const duration_type& timeout) = 0;
 
   /**
    * @brief Determine whether the Queue may be popped from

--- a/include/appfwk/StdDeQueue.hpp
+++ b/include/appfwk/StdDeQueue.hpp
@@ -51,7 +51,7 @@ public:
   void pop(value_type& val, const duration_type&) override; // Throws QueueTimeoutExpired if a timeout occurs
 
   bool can_push() const noexcept override { return fSize.load() < this->GetCapacity(); }
-  void push(value_type&&, const duration_type&) override; // Throws std::runtime_error if a timeout occurs
+  void push(value_type&&, const duration_type&) override; // Throws QueueTimeoutExpired if a timeout occurs
 
   // Delete the copy and move operations since various member data instances
   // (e.g., of std::mutex or of std::atomic) aren't copyable or movable

--- a/include/appfwk/StdDeQueue.hpp
+++ b/include/appfwk/StdDeQueue.hpp
@@ -48,7 +48,7 @@ public:
   explicit StdDeQueue(const std::string& name, size_t capacity);
 
   bool can_pop() const noexcept override { return fSize.load() > 0; }
-  bool pop(value_type& val, const duration_type&) override; // Throws std::runtime_error if a timeout occurs
+  void pop(value_type& val, const duration_type&) override; // Throws QueueTimeoutExpired if a timeout occurs
 
   bool can_push() const noexcept override { return fSize.load() < this->GetCapacity(); }
   void push(value_type&&, const duration_type&) override; // Throws std::runtime_error if a timeout occurs

--- a/include/appfwk/detail/FanOutDAQModule.hxx
+++ b/include/appfwk/detail/FanOutDAQModule.hxx
@@ -81,7 +81,12 @@ FanOutDAQModule<ValueType>::do_work(std::atomic<bool>& running_flag)
   while (running_flag.load()) {
     if (inputQueue_->can_pop()) {
 
-      if (!inputQueue_->pop(data, queueTimeout_)) {
+      try
+      {
+        inputQueue_->pop(data, queueTimeout_);
+      }
+      catch (dunedaq::appfwk::QueueTimeoutExpired& excpt)
+      {
         continue;
       }
 

--- a/include/appfwk/detail/FanOutDAQModule.hxx
+++ b/include/appfwk/detail/FanOutDAQModule.hxx
@@ -85,7 +85,7 @@ FanOutDAQModule<ValueType>::do_work(std::atomic<bool>& running_flag)
       {
         inputQueue_->pop(data, queueTimeout_);
       }
-      catch (dunedaq::appfwk::QueueTimeoutExpired& excpt)
+      catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt)
       {
         continue;
       }

--- a/include/appfwk/detail/StdDeQueue.hxx
+++ b/include/appfwk/detail/StdDeQueue.hxx
@@ -39,7 +39,7 @@ StdDeQueue<T>::push(value_type&& object_to_push, const duration_type& timeout)
 }
 
 template<class T>
-bool
+void
 StdDeQueue<T>::pop(T& val, const duration_type& timeout)
 {
 
@@ -59,9 +59,9 @@ StdDeQueue<T>::pop(T& val, const duration_type& timeout)
     fDeque.pop_front();
     fSize--;
     fNoLongerFull.notify_one();
-    return true;
   } else {
-    return false;
+    throw QueueTimeoutExpired(
+      ERS_HERE, NamedObject::get_name(), "pop", std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count());
   }
 }
 

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -96,7 +96,12 @@ FakeDataConsumerDAQModule::do_work(std::atomic<bool>& running_flag)
 
       TLOG(TLVL_TRACE) << get_name() << ": Going to receive data from inputQueue";
 
-      if (!inputQueue_->pop(vec, queueTimeout_)) {
+      try
+      {
+        inputQueue_->pop(vec, queueTimeout_);
+      }
+      catch (dunedaq::appfwk::QueueTimeoutExpired& excpt)
+      {
         continue;
       }
 

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -100,7 +100,7 @@ FakeDataConsumerDAQModule::do_work(std::atomic<bool>& running_flag)
       {
         inputQueue_->pop(vec, queueTimeout_);
       }
-      catch (dunedaq::appfwk::QueueTimeoutExpired& excpt)
+      catch (const dunedaq::appfwk::QueueTimeoutExpired& excpt)
       {
         continue;
       }

--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -120,7 +120,7 @@ add_things()
       msg << "Thread #" << std::this_thread::get_id() << ": completed push";
       TLOG(TLVL_DEBUG) << msg.str();
 
-    } catch (const QueueTimeoutExpired & err) {
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired & err) {
       TLOG(TLVL_WARNING) << "Exception thrown during push attempt: " << err.what();
       throw_pushes++;
     }
@@ -164,7 +164,7 @@ remove_things()
       } else {
         timeout_pops++;
       }
-    } catch (const QueueTimeoutExpired & e) {
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& e) {
       TLOG(TLVL_WARNING) << "Exception thrown during pop attempt: " << e.what();
       throw_pops++;
     }

--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -120,7 +120,7 @@ add_things()
       msg << "Thread #" << std::this_thread::get_id() << ": completed push";
       TLOG(TLVL_DEBUG) << msg.str();
 
-    } catch (const std::runtime_error& err) {
+    } catch (const QueueTimeoutExpired & err) {
       TLOG(TLVL_WARNING) << "Exception thrown during push attempt: " << err.what();
       throw_pushes++;
     }
@@ -164,7 +164,7 @@ remove_things()
       } else {
         timeout_pops++;
       }
-    } catch (const std::runtime_error& e) {
+    } catch (const QueueTimeoutExpired & e) {
       TLOG(TLVL_WARNING) << "Exception thrown during pop attempt: " << e.what();
       throw_pops++;
     }

--- a/unittest/DAQSink_DAQSource_test.cxx
+++ b/unittest/DAQSink_DAQSource_test.cxx
@@ -75,8 +75,9 @@ BOOST_AUTO_TEST_CASE(DataFlow)
   DAQSource<std::string> source("dummy");
 
   sink.push(std::move("hello"));
-  std::string res;
-  source.pop(res);
+  std::string res("undefined");
+  try {source.pop(res);}
+  catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {}
   BOOST_REQUIRE_EQUAL(res, "hello");
 }
 
@@ -88,7 +89,7 @@ BOOST_AUTO_TEST_CASE(Exceptions)
   std::string res;
 
   BOOST_REQUIRE(!source.can_pop());
-  BOOST_REQUIRE(!source.pop(res));
+  BOOST_CHECK_THROW(source.pop(res), dunedaq::appfwk::QueueTimeoutExpired ) ; 
 
   for (int ii = 0; ii < 100; ++ii) {
     BOOST_REQUIRE(sink.can_push());

--- a/unittest/FanOutDAQModule_test.cxx
+++ b/unittest/FanOutDAQModule_test.cxx
@@ -99,11 +99,13 @@ BOOST_AUTO_TEST_CASE(NonCopyableTypeTest)
 
   BOOST_REQUIRE_EQUAL(outputbuf1.can_pop(), true);
   dunedaq::appfwk::NonCopyableType res(0);
-  outputbuf1.pop(res, queue_timeout);
+  try {outputbuf1.pop(res, queue_timeout);}
+  catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {}
   BOOST_REQUIRE_EQUAL(res.data, 1);
 
   BOOST_REQUIRE_EQUAL(outputbuf2.can_pop(), true);
-  outputbuf2.pop(res, queue_timeout);
+  try {outputbuf2.pop(res, queue_timeout);}
+  catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {}
   BOOST_REQUIRE_EQUAL(res.data, 2);
 }
 

--- a/unittest/FollyQueue_test.cxx
+++ b/unittest/FollyQueue_test.cxx
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
 
   starttime = std::chrono::steady_clock::now();
   int popped_value ; 
-  Queue.pop( popped_value, timeout);
+  try {Queue.pop( popped_value, timeout);}
+  catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {}
   auto pop_time = std::chrono::steady_clock::now() - starttime;
 
   if (pop_time > timeout) {
@@ -89,9 +90,12 @@ BOOST_AUTO_TEST_CASE(empty_checks,
   try {
     while (Queue.can_pop()) {
       int popped_value ; 
-      if ( ! Queue.pop(popped_value, timeout) ) {
+      try {
+        Queue.pop(popped_value, timeout);
+      }
+      catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {
 	BOOST_TEST(false,
-		   "False returned in call to FollyQueue::pop(); unable "
+		   "Exception thrown in call to FollyQueue::pop(); unable "
 		   "to empty the Queue");
 	break ;
       }
@@ -107,7 +111,7 @@ BOOST_AUTO_TEST_CASE(empty_checks,
   int popped_value ; 
   
   auto starttime = std::chrono::steady_clock::now();
-  BOOST_TEST( ! Queue.pop(popped_value, timeout) ) ; 
+  BOOST_CHECK_THROW(Queue.pop(popped_value, timeout), dunedaq::appfwk::QueueTimeoutExpired ) ; 
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
   
   const double fraction_of_pop_timeout_used = pop_duration / timeout;

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -23,8 +23,6 @@ BOOST_AUTO_TEST_SUITE(StdDeQueue_test)
 namespace {
 
 constexpr int max_testable_capacity = 1000000000;    ///< The maximum capacity this test will attempt to check
-constexpr double fractional_timeout_tolerance = 0.1; ///< The fraction of the timeout which the timing is allowed to be
-                                                     ///< off by
 
 /**
  * @brief Timeout to use for tests
@@ -112,8 +110,8 @@ BOOST_AUTO_TEST_CASE(empty_checks)
 
   BOOST_TEST_MESSAGE("Attempted pop_duration divided by timeout is " << fraction_of_pop_timeout_used);
 
-  BOOST_CHECK_GT(fraction_of_pop_timeout_used, 1 - fractional_timeout_tolerance);
-  BOOST_CHECK_LT(fraction_of_pop_timeout_used, 1 + fractional_timeout_tolerance);
+  BOOST_CHECK_GT(fraction_of_pop_timeout_used, 1);
+  BOOST_CHECK_LT(fraction_of_pop_timeout_used, 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -103,12 +103,9 @@ BOOST_AUTO_TEST_CASE(empty_checks)
   int popped_value;
 
   auto starttime = std::chrono::steady_clock::now();
-  try {
-    Queue.pop(popped_value, timeout);
-  }
-  catch (dunedaq::appfwk::QueueTimeoutExpired& ex) {
-    BOOST_TEST(false);
-  }
+
+  BOOST_CHECK_THROW(Queue.pop(timeout), dunedaq::appfwk::QueueTimeoutExpired ) ; 
+
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
 
   const double fraction_of_pop_timeout_used = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(pop_duration).count())/std::chrono::duration_cast<std::chrono::nanoseconds>(timeout).count();

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
   starttime = std::chrono::steady_clock::now();
   int popped_value;
   try {Queue.pop(popped_value, timeout);}
-  catch (dunedaq::appfwk::QueueTimeoutExpired& ex) {}
+  catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {}
   auto pop_time = std::chrono::steady_clock::now() - starttime;
 
   if (pop_time > timeout) {
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(empty_checks)
       try {
         Queue.pop(popped_value, timeout);
       }
-      catch (dunedaq::appfwk::QueueTimeoutExpired& ex) {
+      catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {
         BOOST_TEST(false,
                    "Exception thrown in call to StdDeQueue::pop(); unable "
                    "to empty the Queue");
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(empty_checks)
 
   auto starttime = std::chrono::steady_clock::now();
 
-  BOOST_CHECK_THROW(Queue.pop(timeout), dunedaq::appfwk::QueueTimeoutExpired ) ; 
+  BOOST_CHECK_THROW(Queue.pop(popped_value, timeout), dunedaq::appfwk::QueueTimeoutExpired ) ; 
 
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
 

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
 
   starttime = std::chrono::steady_clock::now();
   int popped_value;
-  Queue.pop(popped_value, timeout);
+  try {Queue.pop(popped_value, timeout);}
+  catch (dunedaq::appfwk::QueueTimeoutExpired& ex) {}
   auto pop_time = std::chrono::steady_clock::now() - starttime;
 
   if (pop_time > timeout) {
@@ -84,9 +85,12 @@ BOOST_AUTO_TEST_CASE(empty_checks)
 {
     while (Queue.can_pop()) {
       int popped_value;
-      if (!Queue.pop(popped_value, timeout)) {
+      try {
+        Queue.pop(popped_value, timeout);
+      }
+      catch (dunedaq::appfwk::QueueTimeoutExpired& ex) {
         BOOST_TEST(false,
-                   "False returned in call to StdDeQueue::pop(); unable "
+                   "Exception thrown in call to StdDeQueue::pop(); unable "
                    "to empty the Queue");
         break;
       }
@@ -99,7 +103,12 @@ BOOST_AUTO_TEST_CASE(empty_checks)
   int popped_value;
 
   auto starttime = std::chrono::steady_clock::now();
-  BOOST_TEST(!Queue.pop(popped_value, timeout));
+  try {
+    Queue.pop(popped_value, timeout);
+  }
+  catch (dunedaq::appfwk::QueueTimeoutExpired& ex) {
+    BOOST_TEST(false);
+  }
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
 
   const double fraction_of_pop_timeout_used = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(pop_duration).count())/std::chrono::duration_cast<std::chrono::nanoseconds>(timeout).count();


### PR DESCRIPTION
This pull request is to ask for approval to merge the changes on the biery/Issue73_pop_throws_exception branch into the develop branch.

The changes on that branch are ones needed to convert the Queue pop method from returning a boolean to throwing an exception when no element is available to pop within the specified timeout.