### PR TITLE
JCF: remove explicit find_package calls for cetlib and folly since qu…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(appfwk)
 
-find_package(cetlib REQUIRED)
-find_package(folly REQUIRED)
-
 set(DAQ_LIBRARIES_PACKAGE ${CETLIB} ${CETLIB_EXCEPT} appfwk)
 
 ##############################################################################


### PR DESCRIPTION
…ick-start.sh here is assumed to be taken from daq-buildtools' jcfreeman2/appfwk_issue70

Let me reiterate: do NOT pull this until you've pulled daq-buildtools' pull request 9. It's in that daq-buildtools pull request that quick-start.sh constructs the superproject CMakeLists.txt so that along with find_packaging Boost, TRACE, etc. it also find_packages cetlib and folly. Note that even if you don't pull this code, the develop branch of appfwk will work against the installation and build scripts in daq-buildtools' Issue 9. 