### PR TITLE
JCF: bring codebase significantly closer into compliance with the DUN…

### DIFF
--- a/include/appfwk/CommandFacility.hpp
+++ b/include/appfwk/CommandFacility.hpp
@@ -76,7 +76,7 @@ public:
    * This function should block for the lifetime of the DAQ Application, calling
    * DAQProcess::execute_command as necessary
    */
-  virtual int listen(DAQProcess* /*process*/) { return 0; }
+  virtual int listen(const DAQProcess& /*process*/) const { return 0; }
 
 protected:
   /**

--- a/include/appfwk/CommandLineInterpreter.hpp
+++ b/include/appfwk/CommandLineInterpreter.hpp
@@ -85,14 +85,14 @@ public:
       output.servicePluginNames = vm["service"].as<std::vector<std::string>>();
     }
     if (vm.count("configJson")) {
-      output.applicaitonConfigurationFile = vm["configJson"].as<std::string>();
+      output.applicationConfigurationFile = vm["configJson"].as<std::string>();
     }
     output.isValid = true;
     return output;
   }
 
   bool isValid{ false };                       ///< Whether the command line was successfully parsed
-  std::string applicaitonConfigurationFile;    ///< File that contains application
+  std::string applicationConfigurationFile;    ///< File that contains application
                                                ///< configuration (JSON)
   std::string commandFacilityPluginName;       ///< Name of the CommandFacility plugin to load
   std::string configurationManagerPluginName;  ///< Name of the ConfigurationManager

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -95,7 +95,7 @@ public:
 
   std::vector<std::string> get_commands() const;
 
-  bool has_command(const std::string name) const;
+  bool has_command(const std::string& name) const;
 
 protected:
   /**

--- a/include/appfwk/DAQProcess.hpp
+++ b/include/appfwk/DAQProcess.hpp
@@ -54,7 +54,7 @@ public:
    * needed by this DAQ Application. ConstructGraph also defines any ordering of
    * commands for DAQModules.
    */
-  void register_modules(GraphConstructor& gc);
+  void register_modules(const GraphConstructor& gc);
   /**
    * @brief Execute the specified command on the loaded DAQModules
    * @param cmd Command to execute
@@ -65,7 +65,7 @@ public:
    * that list in the order specified. Then, any remaining DAQModules will
    * receive the command in an unspecified order.
    */
-  void execute_command(std::string const& cmd, std::vector<std::string> const& args = {});
+  void execute_command(std::string const& cmd, std::vector<std::string> const& args = {}) const;
   /**
    * @brief Start the CommandFacility listener
    * @return Return code from listener
@@ -74,7 +74,7 @@ public:
    * should block for the duration of the DAQ Application, calling
    * execute_command as necessary.
    */
-  int listen();
+  int listen() const;
 
   DAQProcess(const DAQProcess&) = delete;            ///< DAQProcess is not copy-constuctible
   DAQProcess& operator=(const DAQProcess&) = delete; ///< DAQProcess is not copy-assignable
@@ -88,7 +88,7 @@ protected:
    * @param cmd Command name
    * @param args Command arguments
    */
-  void call_command_on_module(DAQModule& module, const std::string& cmd, std::vector<std::string> const& args);
+  void call_command_on_module(DAQModule& module, const std::string& cmd, std::vector<std::string> const& args) const;
 
 private:
   DAQModuleMap daqModuleMap_;       ///< String alias for each DAQModule

--- a/include/appfwk/DAQSink.hpp
+++ b/include/appfwk/DAQSink.hpp
@@ -42,7 +42,7 @@ public:
   explicit DAQSink(const std::string& name);
   void push(T&& element, const duration_type& timeout = duration_type::zero());
   void push(const T& element, const duration_type& timeout = duration_type::zero());
-  bool can_push();
+  bool can_push() const noexcept;
 
 private:
   std::shared_ptr<Queue<T>> queue_;
@@ -54,7 +54,7 @@ DAQSink<T>::DAQSink(const std::string& name)
   try {
     queue_ = QueueRegistry::get().get_queue<T>(name);
     TLOG(TLVL_TRACE, "DAQSink") << "Queue " << name << " is at " << queue_.get();
-  } catch (QueueTypeMismatch& ex) {
+  } catch (const QueueTypeMismatch& ex) {
     throw DAQSinkConstructionFailed(ERS_HERE, name, ex);
   }
 }
@@ -75,7 +75,7 @@ DAQSink<T>::push(const T& element, const duration_type& timeout)
 
 template<typename T>
 bool
-DAQSink<T>::can_push()
+DAQSink<T>::can_push() const noexcept
 {
   return queue_->can_push();
 }

--- a/include/appfwk/DAQSource.hpp
+++ b/include/appfwk/DAQSource.hpp
@@ -39,7 +39,7 @@ public:
 
   explicit DAQSource(const std::string& name);
   void pop(T&, const duration_type& timeout = duration_type::zero());
-  bool can_pop();
+  bool can_pop() const noexcept;
 
 private:
   std::shared_ptr<Queue<T>> queue_;
@@ -65,7 +65,7 @@ DAQSource<T>::pop(T& val, const duration_type& timeout)
 
 template<typename T>
 bool
-DAQSource<T>::can_pop()
+DAQSource<T>::can_pop() const noexcept
 {
   return queue_->can_pop();
 }

--- a/include/appfwk/FanOutDAQModule.hpp
+++ b/include/appfwk/FanOutDAQModule.hpp
@@ -113,10 +113,9 @@ private:
   typename std::enable_if_t<std::is_copy_constructible_v<U>> do_broadcast(ValueType& data) const
   {
     for (auto& o : outputQueues_) {
-      auto starttime = std::chrono::steady_clock::now();
-      o->push(data, queueTimeout_);
-      auto endtime = std::chrono::steady_clock::now();
-      if (std::chrono::duration_cast<decltype(queueTimeout_)>(endtime - starttime) > queueTimeout_) {
+      try {
+	o->push(data, queueTimeout_);
+      } catch (const QueueTimeoutExpired& ex) {
         ers::warning(BroadcastFailed(ERS_HERE,
                                      get_name(),
                                      "Timeout occurred trying to broadcast data to "

--- a/include/appfwk/FollyQueue.hpp
+++ b/include/appfwk/FollyQueue.hpp
@@ -49,7 +49,6 @@ public:
 
   void push(value_type&& t, const duration_type& dur) override
   {
-    // Is the std::move actually necessary here?
     if (!fQueue.try_enqueue_for(std::move(t), dur)) {
       throw QueueTimeoutExpired(
         ERS_HERE, NamedObject::get_name(), "push", std::chrono::duration_cast<std::chrono::milliseconds>(dur).count());

--- a/include/appfwk/GraphConstructor.hpp
+++ b/include/appfwk/GraphConstructor.hpp
@@ -44,7 +44,7 @@ public:
    * Queue and DAQModule instances in a DAQ Application. Additionally, any
    * requirements on command order for DAQModules should be defined here.
    */
-  virtual void ConstructGraph(DAQModuleMap& daq_module_map, CommandOrderMap& command_order_map) = 0;
+  virtual void ConstructGraph(DAQModuleMap& daq_module_map, CommandOrderMap& command_order_map) const = 0;
 };
 } // namespace dunedaq::appfwk
 

--- a/include/appfwk/NamedObject.hpp
+++ b/include/appfwk/NamedObject.hpp
@@ -39,7 +39,7 @@ public:
   const std::string& get_name() const { return name_; }
 
 private:
-  std::string name_;
+  const std::string name_;
 };
 } // namespace dunedaq::appfwk
 #endif // APPFWK_INCLUDE_APPFWK_NAMEDOBJECT_HPP_

--- a/include/appfwk/NamedObject.hpp
+++ b/include/appfwk/NamedObject.hpp
@@ -26,21 +26,19 @@ public:
   // explicit Named(const std::string& name)
   //   : name_(name)
   // {}
-  Named() = default;                             ///< Named is default-constructible
+  Named() = default;                       ///< Named is default-constructible
   Named(Named const&) = delete;            ///< Named is not copy-constructible
   Named(Named&&) = default;                ///< Named is move-constructible
   Named& operator=(Named const&) = delete; ///< Named is not copy-assignable
   Named& operator=(Named&&) = default;     ///< Named is move-assignable
-  virtual ~Named() = default;                    ///< Default virtual destructor
+  virtual ~Named() = default;              ///< Default virtual destructor
 
   /**
    * @brief Get the name of this NamedObejct
    * @return The name of this Named
    */
   virtual const std::string& get_name() const = 0;
-
 };
-
 
 /**
  * @brief Implements the Named interface
@@ -56,13 +54,17 @@ public:
     : name_(name)
   {}
 
+  NamedObject(NamedObject const&) = delete;            ///< NamedObject is not copy-constructible
+  NamedObject(NamedObject&&) = default;                ///< NamedObject is move-constructible
+  NamedObject& operator=(NamedObject const&) = delete; ///< NamedObject is not copy-assignable
+  NamedObject& operator=(NamedObject&&) = default;     ///< NamedObject is move-assignable
   virtual ~NamedObject() = default;                    ///< Default virtual destructor
 
   /**
    * @brief Get the name of this NamedObejct
    * @return The name of this Named
    */
-  const std::string& get_name() const final {return name_; }
+  const std::string& get_name() const final { return name_; }
 
 private:
   const std::string name_;

--- a/include/appfwk/QueueRegistry.hpp
+++ b/include/appfwk/QueueRegistry.hpp
@@ -61,7 +61,7 @@ public:
   /**
    * @brief QueueRegistry destructor
    */
-  ~QueueRegistry();
+  ~QueueRegistry() = default;
 
   /**
    * @brief Get a handle to the QueueRegistry
@@ -91,17 +91,17 @@ private:
     std::shared_ptr<NamedObject> instance;
   };
 
-  QueueRegistry();
+  QueueRegistry() = default;
 
   template<typename T>
-  std::shared_ptr<NamedObject> create_queue(std::string name, const QueueConfig& config);
+  std::shared_ptr<NamedObject> create_queue(const std::string& name, const QueueConfig& config);
 
   std::map<std::string, QueueEntry> queue_registry_;
   std::map<std::string, QueueConfig> queue_configmap_;
 
   bool configured_{ false };
 
-  static QueueRegistry* me_;
+  static std::unique_ptr<QueueRegistry> me_;
 
   QueueRegistry(const QueueRegistry&) = delete;
   QueueRegistry& operator=(const QueueRegistry&) = delete;

--- a/include/appfwk/detail/FanOutDAQModule.hxx
+++ b/include/appfwk/detail/FanOutDAQModule.hxx
@@ -52,7 +52,8 @@ FanOutDAQModule<ValueType>::do_configure(const std::vector<std::string>& /*args*
     mode_ = FanOutMode::RoundRobin;
   }
 
-  wait_interval_us_ = get_config().value<int>("wait_interval", 10000);
+  wait_interval_us_ = get_config().value<int>("wait_interval_us", 10000);
+  queueTimeout_ = std::chrono::milliseconds(get_config().value<int>("queue_timeout_ms", 100));
 }
 
 template<typename ValueType>

--- a/include/appfwk/detail/QueueRegistry.hxx
+++ b/include/appfwk/detail/QueueRegistry.hxx
@@ -29,7 +29,8 @@ QueueRegistry::get_queue(const std::string& name)
     auto queuePtr = std::dynamic_pointer_cast<Queue<T>>(itQ->second.instance);
 
     if (!queuePtr) {
-      int status;
+      // TODO: John Freeman (jcfree@fnal.gov), Jun-23-2020. Add checks for demangling status. Timescale 2 weeks.
+      int status = -999;
       std::string realname_target = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
       std::string realname_source = abi::__cxa_demangle(itQ->second.type->name(), 0, 0, &status);
 
@@ -46,7 +47,8 @@ QueueRegistry::get_queue(const std::string& name)
     return std::dynamic_pointer_cast<Queue<T>>(entry.instance);
 
   } else {
-    int status;
+    // TODO: John Freeman (jcfree@fnal.gov), Jun-23-2020. Add checks for demangling status. Timescale 2 weeks.
+    int status = -999;
     std::string realname_target = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
     throw QueueNotFound(ERS_HERE, name, realname_target);
   }
@@ -54,7 +56,7 @@ QueueRegistry::get_queue(const std::string& name)
 
 template<typename T>
 std::shared_ptr<NamedObject>
-QueueRegistry::create_queue(std::string name, const QueueConfig& config)
+QueueRegistry::create_queue(const std::string& name, const QueueConfig& config)
 {
 
   std::shared_ptr<NamedObject> queue;

--- a/src/DAQModule.cpp
+++ b/src/DAQModule.cpp
@@ -41,7 +41,7 @@ DAQModule::get_commands() const
 }
 
 bool
-DAQModule::has_command(const std::string name) const
+DAQModule::has_command(const std::string& name) const
 {
   return (commands_.find(name) != commands_.end());
 }

--- a/src/DAQProcess.cpp
+++ b/src/DAQProcess.cpp
@@ -35,17 +35,17 @@ DAQProcess::DAQProcess(CommandLineInterpreter args)
 }
 
 void
-DAQProcess::register_modules(GraphConstructor& ml)
+DAQProcess::register_modules(const GraphConstructor& ml)
 {
   ml.ConstructGraph(daqModuleMap_, commandOrderMap_);
 }
 
 void
-DAQProcess::execute_command(std::string const& cmd, std::vector<std::string> const& args)
+DAQProcess::execute_command(std::string const& cmd, std::vector<std::string> const& args) const
 {
   std::unordered_set<std::string> daq_module_list;
   for (auto const& dm : daqModuleMap_) {
-    // TODO: works, but it's too simple. Needs better handling.
+    // TODO: Alessandro Thea (Alessandro.Thea@cern.ch), Jun-19-2020. Works, but it's too simple. Needs better handling. Timescale TBD. 
     if (!dm.second->has_command(cmd)) {
       ERS_INFO("Module " << dm.first << " does not have " << cmd);
       continue;
@@ -57,10 +57,10 @@ DAQProcess::execute_command(std::string const& cmd, std::vector<std::string> con
   TLOG(TLVL_TRACE) << "Executing Command " << cmd << " for DAQModules defined in the CommandOrderMap";
 
   if (commandOrderMap_.count(cmd)) {
-    for (auto& moduleName : commandOrderMap_[cmd]) {
+    for (auto const& moduleName : commandOrderMap_.at(cmd)) {
       if (daqModuleMap_.count(moduleName)) {
 
-        call_command_on_module(*daqModuleMap_[moduleName], cmd, args);
+        call_command_on_module(*daqModuleMap_.at(moduleName), cmd, args);
 
         daq_module_list.erase(moduleName);
       }
@@ -73,25 +73,26 @@ DAQProcess::execute_command(std::string const& cmd, std::vector<std::string> con
   TLOG(TLVL_TRACE) << "Executing Command " << cmd << " for all remaining DAQModules";
   for (auto const& moduleName : daq_module_list) {
 
-    call_command_on_module(*daqModuleMap_[moduleName], cmd, args);
+    call_command_on_module(*daqModuleMap_.at(moduleName), cmd, args);
   }
 }
 
 int
-DAQProcess::listen()
+DAQProcess::listen() const
 {
-  return CommandFacility::handle().listen(this);
+  return CommandFacility::handle().listen(*this);
 }
 
 void
-DAQProcess::call_command_on_module(DAQModule& mod, const std::string& cmd, std::vector<std::string> const& args)
+DAQProcess::call_command_on_module(DAQModule& mod, const std::string& cmd, std::vector<std::string> const& args) const
 {
 
   try {
     mod.execute_command(cmd, args);
   } catch (GeneralDAQModuleIssue& ex) {
     ers::error(ex);
-  } catch (...) { // NOLINT
+  } catch (const std::exception& ex) { 
+    TLOG(TLVL_TRACE) << "Caught non-GeneralDAQModuleIssue exception thrown from module inside DAQProcess::call_command_on_module: " << ex.what();
     ers::error(ModuleThrowUnknown(ERS_HERE, mod.get_name(), cmd));
   }
 }

--- a/src/QueryResponseCommandFacility.cpp
+++ b/src/QueryResponseCommandFacility.cpp
@@ -15,7 +15,7 @@
 namespace dunedaq::appfwk {
 
 int
-QueryResponseCommandFacility::listen(DAQProcess* process)
+QueryResponseCommandFacility::listen(const DAQProcess& process) const
 {
   try {
     bool keepGoing = true;
@@ -28,7 +28,7 @@ QueryResponseCommandFacility::listen(DAQProcess* process)
         keepGoing = false;
         break;
       } else {
-        process->execute_command(comm);
+        process.execute_command(comm);
       }
     }
   } catch (...) // NOLINT

--- a/src/QueryResponseCommandFacility.hpp
+++ b/src/QueryResponseCommandFacility.hpp
@@ -32,7 +32,7 @@ public:
    * @return Status code. 0 if terminated by quit command, -1 if an exception
    * occurs
    */
-  int listen(DAQProcess* theProcess) override;
+  int listen(const DAQProcess& theProcess) const override;
   virtual ~QueryResponseCommandFacility();
 
   QueryResponseCommandFacility() = default;

--- a/src/QueueRegistry.cpp
+++ b/src/QueueRegistry.cpp
@@ -11,21 +11,18 @@
 #include "appfwk/QueueRegistry.hpp"
 
 #include <map>
+#include <memory>
 #include <string>
 
 namespace dunedaq::appfwk {
 
-QueueRegistry* QueueRegistry::me_ = nullptr;
-
-QueueRegistry::QueueRegistry() {}
-
-QueueRegistry::~QueueRegistry() {}
+  std::unique_ptr<QueueRegistry> QueueRegistry::me_ = nullptr;
 
 QueueRegistry&
 QueueRegistry::get()
 {
   if (!me_) {
-    me_ = new QueueRegistry();
+    me_.reset( new QueueRegistry() );
   }
   return *me_;
 }

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -28,9 +28,6 @@ namespace dunedaq::appfwk {
 FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(const std::string& name)
   : DAQModule(name)
   , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this, std::placeholders::_1))
-  , nIntsPerVector_(999)
-  , starting_int_(-999)
-  , ending_int_(-999)
   , queueTimeout_(100)
   , inputQueue_(nullptr)
 {

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -50,6 +50,7 @@ FakeDataConsumerDAQModule::do_configure(const std::vector<std::string>& /*args*/
   nIntsPerVector_ = get_config().value<int>("nIntsPerVector", 10);
   starting_int_ = get_config().value<int>("starting_int", -4);
   ending_int_ = get_config().value<int>("ending_int", 14);
+  queueTimeout_ = std::chrono::milliseconds(get_config().value<int>("queue_timeout_ms", 100));
 }
 
 void

--- a/test/FakeDataConsumerDAQModule.cpp
+++ b/test/FakeDataConsumerDAQModule.cpp
@@ -28,6 +28,9 @@ namespace dunedaq::appfwk {
 FakeDataConsumerDAQModule::FakeDataConsumerDAQModule(const std::string& name)
   : DAQModule(name)
   , thread_(std::bind(&FakeDataConsumerDAQModule::do_work, this, std::placeholders::_1))
+  , nIntsPerVector_(999)
+  , starting_int_(-999)
+  , ending_int_(-999)
   , queueTimeout_(100)
   , inputQueue_(nullptr)
 {

--- a/test/FakeDataConsumerDAQModule.hpp
+++ b/test/FakeDataConsumerDAQModule.hpp
@@ -60,9 +60,9 @@ private:
   ThreadHelper thread_;
 
   // Configuration (for validation)
-  size_t nIntsPerVector_;
-  int starting_int_;
-  int ending_int_;
+  size_t nIntsPerVector_ = 999;
+  int starting_int_ = -999;
+  int ending_int_ = -999;
   std::chrono::milliseconds queueTimeout_;
   std::unique_ptr<DAQSource<std::vector<int>>> inputQueue_;
 };

--- a/test/FakeDataProducerDAQModule.cpp
+++ b/test/FakeDataProducerDAQModule.cpp
@@ -29,11 +29,6 @@ FakeDataProducerDAQModule::FakeDataProducerDAQModule(const std::string& name)
   , thread_(std::bind(&FakeDataProducerDAQModule::do_work, this, std::placeholders::_1))
   , outputQueue_(nullptr)
   , queueTimeout_(100)
-  , nIntsPerVector_(999)
-  , starting_int_(-999)
-  , ending_int_(-999)
-  , wait_between_sends_ms_(999)
-    
 {
 
   register_command("configure", &FakeDataProducerDAQModule::do_configure);
@@ -114,7 +109,7 @@ FakeDataProducerDAQModule::do_work(std::atomic<bool>& running_flag)
     try {
       outputQueue_->push(std::move(output), queueTimeout_);
     } catch(const QueueTimeoutExpired& ex) {
-      TLOG(TLVL_TRACE) << "Push resulted in a timeout in FakeDataProducerDAQModule::do_work; data may be lost!";
+      ers::warning(ex);
     }
 
     TLOG(TLVL_TRACE) << get_name() << ": Start of sleep between sends";

--- a/test/FakeDataProducerDAQModule.cpp
+++ b/test/FakeDataProducerDAQModule.cpp
@@ -49,6 +49,7 @@ FakeDataProducerDAQModule::do_configure(const std::vector<std::string>& /*args*/
   starting_int_ = get_config().value<int>("starting_int", -4);
   ending_int_ = get_config().value<int>("ending_int", 14);
   wait_between_sends_ms_ = get_config().value<int>("wait_between_sends_ms", 1000);
+  queueTimeout_ = std::chrono::milliseconds(get_config().value<int>("queue_timeout_ms", 100));
 }
 
 void

--- a/test/FakeDataProducerDAQModule.hpp
+++ b/test/FakeDataProducerDAQModule.hpp
@@ -61,11 +61,11 @@ private:
   // Configuration
   std::unique_ptr<DAQSink<std::vector<int>>> outputQueue_;
   std::chrono::milliseconds queueTimeout_;
-  size_t nIntsPerVector_;
-  int starting_int_;
-  int ending_int_;
+  size_t nIntsPerVector_ = 999;
+  int starting_int_ = -999;
+  int ending_int_ = -999;
 
-  size_t wait_between_sends_ms_;
+  size_t wait_between_sends_ms_ = 999;
 };
 } // namespace appfwk
 

--- a/test/dummy_test_app.cxx
+++ b/test/dummy_test_app.cxx
@@ -20,7 +20,7 @@ namespace dunedaq::appfwk {
 class dummy_test_app_contructor : public GraphConstructor
 {
   // Inherited via ModuleList
-  void ConstructGraph(DAQModuleMap& user_module_map, CommandOrderMap& /*command_order_map*/) override
+  void ConstructGraph(DAQModuleMap& user_module_map, CommandOrderMap& /*command_order_map*/) const override
   {
     user_module_map["dummy"].reset(new DummyModule("test_dummy"));
   }

--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -34,6 +34,13 @@ namespace bpo = boost::program_options;
 #include <utility>
 #include <vector>
 
+namespace dunedaq {
+ERS_DECLARE_ISSUE(appfwk,                 ///< Namespace
+                  ParameterDomainIssue,  ///< Issue class name
+                  "ParameterDomainIssue: \"" << ers_messg << "\"",
+		  ((std::string)ers_messg))
+} // namespace dunedaq
+
 namespace {
 
 /**
@@ -52,7 +59,7 @@ auto timeout = std::chrono::milliseconds(100); ///< Queue's timeout
  */
 std::unique_ptr<dunedaq::appfwk::Queue<int>> queue = nullptr;
 
-int nelements = 10000000; ///< Number of elements to push to the Queue (total)
+int nelements = 1000000; ///< Number of elements to push to the Queue (total)
 int n_adding_threads = 1;      ///< Number of threads which will call push
 int n_removing_threads = 1;    ///< Number of threads which will call pop
 
@@ -250,29 +257,29 @@ main(int argc, char* argv[])
     nelements = vm["nelements"].as<int>();
 
     if (nelements <= 0) {
-      throw std::domain_error("# of elements must be a positive integer");
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of elements must be a positive integer");
     }
   }
 
   if (vm.count("push_threads")) {
     n_adding_threads = vm["push_threads"].as<int>();
 
-    if (n_adding_threads <= 0) {
-      throw std::domain_error("# of pushing threads must be a positive integer");
+    if (n_adding_threads < 0) {
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of pushing threads must be non-negative");
     }
-    if (queue_type == "FollySPSCQueue" && n_adding_threads != 1) {
-      throw std::domain_error("# of pushing threads must be 1 for SPSC queue");
+    if (queue_type == "FollySPSCQueue" && n_adding_threads != 0 && n_adding_threads != 1) {
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of pushing threads must 0 or 1 for SPSC queue");
     }
   }
 
   if (vm.count("pop_threads")) {
     n_removing_threads = vm["pop_threads"].as<int>();
 
-    if (n_removing_threads <= 0) {
-      throw std::domain_error("# of popping threads must be a positive integer");
+    if (n_removing_threads < 0) {
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of popping threads must be non-negative");
     }
-    if (queue_type == "FollySPSCQueue" && n_removing_threads != 1) {
-      throw std::domain_error("# of popping threads must be 1 for SPSC queue");
+    if (queue_type == "FollySPSCQueue" && n_removing_threads != 0 && n_removing_threads != 1) {
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of popping threads must 0 or 1 for SPSC queue");
     }
   }
 
@@ -280,8 +287,7 @@ main(int argc, char* argv[])
     avg_milliseconds_between_pushes = vm["pause_between_pushes"].as<int>();
 
     if (avg_milliseconds_between_pushes < 0) {
-      throw std::domain_error("Average # of milliseconds between pushes must "
-                              "not be a negative number");
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "Average # of milliseconds between pushes must be non-negative");
     }
   }
 
@@ -289,8 +295,7 @@ main(int argc, char* argv[])
     avg_milliseconds_between_pops = vm["pause_between_pops"].as<int>();
 
     if (avg_milliseconds_between_pops < 0) {
-      throw std::domain_error("Average # of milliseconds between pops must not "
-                              "be a negative number");
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "Average # of milliseconds between pops must be non-negative");
     }
   }
 
@@ -298,8 +303,7 @@ main(int argc, char* argv[])
     initial_capacity_used = vm["initial_capacity_used"].as<double>();
 
     if (initial_capacity_used < 0 || initial_capacity_used > 1) {
-      throw std::domain_error("Initial fractional capacity of queue which is "
-                              "used must lie in the range [0, 1]");
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "Initial fractional capacity of queue which is used must lie in the range [0, 1]");
     }
   }
 
@@ -334,7 +338,7 @@ main(int argc, char* argv[])
       std::ostringstream msg;
       msg << "Since capacity of queue exceeds " << max_capacity
           << ", the initial fractional used capacity of the queue must be 0";
-      throw std::domain_error(msg.str());
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, msg.str());
     }
   }
 #endif

--- a/unittest/FollyQueue_test.cxx
+++ b/unittest/FollyQueue_test.cxx
@@ -22,7 +22,7 @@ namespace {
 
 constexpr int max_testable_capacity = 1000000000; ///< The maximum capacity this test will attempt to check
 constexpr double fractional_timeout_tolerance =
-  0.1; ///< The fraction of the timeout which the timing is allowed to be off by
+  0.5; ///< The fraction of the timeout which the timing is allowed to be off by
 
 /**
  * @brief Timeout to use for tests
@@ -48,7 +48,14 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
   BOOST_REQUIRE(!Queue.can_pop());
 
   auto starttime = std::chrono::steady_clock::now();
-  Queue.push(999, timeout);
+  try {
+    Queue.push(42, timeout);
+  } catch(const dunedaq::appfwk::QueueTimeoutExpired& ex) {
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected timeout exception throw from push");
+  } catch(...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected exception (non-timeout-related) thrown");
+  }
+
   auto push_time = std::chrono::steady_clock::now() - starttime;
 
   if (push_time > timeout) {
@@ -63,54 +70,58 @@ BOOST_AUTO_TEST_CASE(sanity_checks)
   BOOST_REQUIRE(Queue.can_pop());
 
   starttime = std::chrono::steady_clock::now();
-  int popped_value;
+  int popped_value = -999;
   try {
     Queue.pop(popped_value, timeout);
   } catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected timeout exception throw from pop");
+  } catch (...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected exception (non-timeout-related) thrown");
   }
+
+
   auto pop_time = std::chrono::steady_clock::now() - starttime;
 
   if (pop_time > timeout) {
     auto pop_time_in_us = std::chrono::duration_cast<std::chrono::microseconds>(pop_time).count();
     BOOST_TEST_REQUIRE(false,
                        "Test failure: popping element off Queue "
-                       "resulted in a timeout (function exited after "
+                       "resulted in a timeout without an exception throw (function exited after "
                          << pop_time_in_us << " microseconds, timeout is " << timeout_in_us << " microseconds)");
   }
 
-  BOOST_REQUIRE_EQUAL(popped_value, 999);
+  BOOST_REQUIRE_EQUAL(popped_value, 42);
 }
 
 BOOST_AUTO_TEST_CASE(empty_checks, *boost::unit_test::depends_on("sanity_checks"))
 {
+  int popped_value = -999;
 
-  try {
-    while (Queue.can_pop()) {
-      int popped_value;
-      try {
-        Queue.pop(popped_value, timeout);
-      } catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {
-        BOOST_TEST(false,
-                   "Exception thrown in call to FollyQueue::pop(); unable "
-                   "to empty the Queue");
-        break;
-      }
+  while (Queue.can_pop()) {
+
+    try {
+      Queue.pop(popped_value, timeout);
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& ex) {
+      BOOST_TEST(false,
+		 "Timeout exception thrown in call to FollyQueue::pop(); unable "
+		 "to empty the Queue");
+      break;
     }
-  } catch (const std::runtime_error& err) {
-    BOOST_WARN_MESSAGE(true, err.what());
   }
 
   BOOST_REQUIRE(!Queue.can_pop());
 
   // pop off of an empty Queue
 
-  int popped_value;
-
   auto starttime = std::chrono::steady_clock::now();
   BOOST_CHECK_THROW(Queue.pop(popped_value, timeout), dunedaq::appfwk::QueueTimeoutExpired);
   auto pop_duration = std::chrono::steady_clock::now() - starttime;
 
-  const double fraction_of_pop_timeout_used = pop_duration / timeout;
+  const double fraction_of_pop_timeout_used =
+    static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(pop_duration).count()) /
+    std::chrono::duration_cast<std::chrono::nanoseconds>(timeout).count();
+
+  BOOST_TEST_MESSAGE("Attempted pop_duration divided by timeout is " << fraction_of_pop_timeout_used);
 
   BOOST_CHECK_GT(fraction_of_pop_timeout_used, 1 - fractional_timeout_tolerance);
   BOOST_CHECK_LT(fraction_of_pop_timeout_used, 1 + fractional_timeout_tolerance);


### PR DESCRIPTION
…E C++ Style Guide

The header mostly says it all. These are changes which can't (at
currently) get picked up by the linter. Here are some of changes made:

* Error checking
I made an effort to ensure that every function which could throw an exception is wrapped in a try-catch, and every
function which returns a status variable has that variable checked. As I made these changes under a time
constraint, where I was unable to do this, I added TODOs.

* const-ification
Many variables and functions which were logically const but not declared as such are now const.
GraphConstructor::ConstructGraph, CommandFacility::listen, etc.

* Removal of unnecessary interface
E.g., replaced non-owning pointers with references when the address of an object isn't of interest

* Removal of raw owning pointers
...and replacement with smart pointers

* Formatting of TODOs
I retroactively added names, dates and emails to TODOs which were missing these