### PR TITLE
JCF: Issue #99: reinstate pop-only testing

### DIFF
--- a/test/queue_IO_check.cxx
+++ b/test/queue_IO_check.cxx
@@ -2,10 +2,10 @@
  *
  * @file queue_IO_check.cxx
  *
- * A low-level test of queue classes which inherit both from
- * QueueSource and QueueSink where we have a user-settable number
- * of threads writing elements to a queue while a user-settable
- * number of threads reads from the queue
+ * A low-level test of queue classes which implement the Queue
+ * interface. We have a user-settable number of threads writing
+ * elements to a queue while a user-settable number of threads reads
+ * from the queue
  *
  * Run "queue_IO_check --help" to see options
  *
@@ -45,10 +45,6 @@ namespace {
 
 /**
  * @brief Type of the queue
- * @todo John Freeman, May-8-2020 (jcfree@fnal.gov)
- * Will replace use of StdDeQueue in the unique_ptr with a base
- * class which supports both push and pop operations if and when one
- * becomes available
  */
 std::string queue_type = "StdDeQueue";
 
@@ -66,13 +62,17 @@ int n_removing_threads = 1;    ///< Number of threads which will call pop
 int avg_milliseconds_between_pushes = 0; ///< Target average rate of pushes
 int avg_milliseconds_between_pops = 0;   ///< Target average rate of pops
 
-std::atomic<size_t> queue_size = 0;     ///< Queue's current size
-std::atomic<size_t> max_queue_size = 0; ///< Queue's maximum size
+// The enable_ options, when set to true, contain code that executes
+// for each push/pop, which will of course affect the overall
+// execution time of the threads while also adding info about the
+// behavior of the system
 
-std::atomic<int> push_attempts = 0;     ///< Number of push attempts in the test
-std::atomic<int> pop_attempts = 0;      ///< Number of pop attempts in the test
-std::atomic<int> successful_pushes = 0; ///< Number of successful pushes in the test
-std::atomic<int> successful_pops = 0;   ///< Number of successful pops in the test
+bool enable_per_pushpop_timing = true;
+bool enable_max_size_checking = true;
+
+std::atomic<int> queue_size = 0;     ///< Queue's current size
+std::atomic<int> max_queue_size = 0; ///< Queue's maximum size
+
 std::atomic<int> timeout_pushes = 0;    ///< Number of pushes which timed out
 std::atomic<int> timeout_pops = 0;      ///< Number of pops which timed out
 std::atomic<int> throw_pushes = 0;      ///< Number of pushes which threw an exception
@@ -96,90 +96,120 @@ std::unique_ptr<std::uniform_int_distribution<int>> pop_distribution =
  * @brief Put elements onto the queue
  */
 void
-add_things()
+add_things(const volatile bool& spinlock)
 {
+  const int npushes = nelements / n_adding_threads;
+  auto starttime_push = std::chrono::steady_clock::now(); // Won't ever use the initialization value
+  auto size_snapshot = queue_size.load(); // Unlike queue_size, only this thread writes to size_snapshot
 
-  for (int i = 0; i < nelements / n_adding_threads; ++i) {
+  while (spinlock) {};  // Main program thread will set this to false, then this thread starts pushing
 
-    std::this_thread::sleep_for(std::chrono::milliseconds((*push_distribution)(generator)));
+  const auto starttime = std::chrono::steady_clock::now();
+  const auto starttime_system = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+  for (int i = 0; i < npushes; ++i) {
+
+    if (avg_milliseconds_between_pushes > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds((*push_distribution)(generator)));
+    }
 
     while (!queue->can_push()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
-    push_attempts++;
+    while (true) {
+      try {
 
-    try {
-      std::ostringstream msg;
-      msg << "Thread #" << std::this_thread::get_id() << ": about to push value " << i
-          << " onto queue with can_pop flag " << std::boolalpha << queue->can_pop();
-      TLOG(TLVL_DEBUG) << msg.str();
+	if (!enable_per_pushpop_timing) {
+	    queue->push(std::move(i), timeout);
+	  } else {
+	  starttime_push = std::chrono::steady_clock::now();
+	  queue->push(std::move(i), timeout);
+	  if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime_push) >
+	      timeout) {
+	    timeout_pushes++;
+	  }
+	}
 
-      auto starttime = std::chrono::steady_clock::now();
-      queue->push(std::move(i), timeout);
-      if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime) <
-          timeout) {
-        successful_pushes++;
-        auto size = queue_size.fetch_add(1) + 1; // fetch_add returns previous value
-        if (size > max_queue_size) {
-          max_queue_size = size;
-        }
-      } else {
-        timeout_pushes++;
+	if (enable_max_size_checking) {
+	    size_snapshot = queue_size.fetch_add(1) + 1; // fetch_add returns previous value
+
+	    if (size_snapshot > max_queue_size) {
+	      max_queue_size = size_snapshot;
+	    }
+	  }
+
+	break;
+      } catch (const dunedaq::appfwk::QueueTimeoutExpired& err) {
+	throw_pushes++;
+	std::ostringstream msg;
+	msg << "Thread #" << std::this_thread::get_id() << ": exception thrown on push #" << i << ": " << err.what();
+	TLOG(TLVL_WARNING) << msg.str();
       }
-      msg.str(std::string());
-      msg << "Thread #" << std::this_thread::get_id() << ": completed push";
-      TLOG(TLVL_DEBUG) << msg.str();
-
-    } catch (const dunedaq::appfwk::QueueTimeoutExpired& err) {
-      TLOG(TLVL_WARNING) << "Exception thrown during push attempt: " << err.what();
-      throw_pushes++;
     }
   }
+
+  std::ostringstream msg;
+  msg << "Thread #" << std::this_thread::get_id() << ": started at " << starttime_system << " ms since epoch, tried pushing " << npushes << " elements; time taken was " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count() << " ms" << "\n";
+  TLOG(TLVL_INFO) << msg.str();
 }
 
 /**
  * @brief Pop elements off of the queue
  */
 void
-remove_things()
+remove_things(const volatile bool& spinlock)   
 {
+  const int npops = n_removing_threads > 0 ? nelements / n_removing_threads : 0;
+  auto starttime_pop = std::chrono::steady_clock::now(); // Won't ever use the initialization value
+  int val = -999;
 
-  for (int i = 0; i < nelements / n_removing_threads; ++i) {
+  while (spinlock) {};  // Main program thread will set this to false, then this thread starts popping
 
-    std::this_thread::sleep_for(std::chrono::milliseconds((*pop_distribution)(generator)));
+  const auto starttime = std::chrono::steady_clock::now();
+  const auto starttime_system = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+  for (int i = 0; i < npops; ++i) {
+
+    if (avg_milliseconds_between_pops > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds((*pop_distribution)(generator)));
+    }
 
     while (!queue->can_pop()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
-    pop_attempts++;
-    int val = -999;
-    try {
-      std::ostringstream msg;
-      msg << "Thread #" << std::this_thread::get_id() << ": about to pop from queue with can_push flag "
-          << std::boolalpha << queue->can_push();
-      TLOG(TLVL_DEBUG) << msg.str();
+    while (true) {
+        try {
 
-      auto starttime = std::chrono::steady_clock::now();
-      queue->pop(val, timeout);
+	  if (!enable_per_pushpop_timing) {
+	      queue->pop(val, timeout);
+	    } else {
+	    starttime_pop = std::chrono::steady_clock::now();
+	    queue->pop(val, timeout);
 
-      msg.str(std::string());
-      msg << "Thread #" << std::this_thread::get_id() << ": completed pop, value is " << val;
-      TLOG(TLVL_DEBUG) << msg.str();
+	    if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime_pop) >
+		timeout) 
+	      timeout_pops++;
+	  }
 
-      if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime) <
-          timeout) {
-        successful_pops++;
-        queue_size--;
-      } else {
-        timeout_pops++;
-      }
-    } catch (const dunedaq::appfwk::QueueTimeoutExpired& e) {
-      TLOG(TLVL_WARNING) << "Exception thrown during pop attempt: " << e.what();
-      throw_pops++;
+	  if (enable_max_size_checking) {
+	      queue_size--;
+	    }
+	  break;
+
+	} catch (const dunedaq::appfwk::QueueTimeoutExpired& e) {
+	  throw_pops++;
+	  std::ostringstream msg;
+	  msg << "Thread #" << std::this_thread::get_id() << ": exception thrown on pop #" << i << ": " << e.what();
+	  TLOG(TLVL_WARNING) << msg.str();
+	}
     }
   }
+
+  std::ostringstream msg;
+  msg << "Thread #" << std::this_thread::get_id() << ": started at " << starttime_system << " ms since epoch, tried popping " << npops << " elements; time taken was " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count() << " ms" << "\n";
+  TLOG(TLVL_INFO) << msg.str();
 }
 
 } // namespace
@@ -222,7 +252,7 @@ main(int argc, char* argv[])
     "pop_threads", bpo::value<int>(), pop_threads_desc.str().c_str())(
     "pause_between_pushes", bpo::value<int>(), push_pause_desc.str().c_str())(
     "pause_between_pops", bpo::value<int>(), pop_pause_desc.str().c_str())(
-    "capacity", bpo::value<int>()->default_value(nelements*2), "queue capacity")(
+    "capacity", bpo::value<int>()->default_value(1000000000), "queue capacity")(
     "initial_capacity_used", bpo::value<double>(), capacity_used_desc.str().c_str())("help,h", "produce help message");
 
   bpo::variables_map vm;
@@ -240,14 +270,14 @@ main(int argc, char* argv[])
     queue_type = vm["queue_type"].as<std::string>();
   }
 
-  size_t capacity = vm["capacity"].as<int>();
+  int capacity = vm["capacity"].as<int>();
 
   if (queue_type == "StdDeQueue") {
-    queue.reset(new dunedaq::appfwk::StdDeQueue<int>("StdDeQueue", capacity));
+    queue.reset(new dunedaq::appfwk::StdDeQueue<int>("StdDeQueue", static_cast<size_t>(capacity)));
   } else if (queue_type == "FollySPSCQueue") {
-    queue.reset(new dunedaq::appfwk::FollySPSCQueue<int>("FollySPSCQueue", capacity));
+    queue.reset(new dunedaq::appfwk::FollySPSCQueue<int>("FollySPSCQueue", static_cast<size_t>(capacity)));
   } else if (queue_type == "FollyMPMCQueue") {
-    queue.reset(new dunedaq::appfwk::FollyMPMCQueue<int>("FollyMPMCQueue", capacity));
+    queue.reset(new dunedaq::appfwk::FollyMPMCQueue<int>("FollyMPMCQueue", static_cast<size_t>(capacity)));
   } else {
     TLOG(TLVL_ERROR) << "Unknown queue type \"" << queue_type << "\" requested for testing";
     return 1;
@@ -262,6 +292,7 @@ main(int argc, char* argv[])
   }
 
   if (vm.count("push_threads")) {
+
     n_adding_threads = vm["push_threads"].as<int>();
 
     if (n_adding_threads < 0) {
@@ -269,6 +300,11 @@ main(int argc, char* argv[])
     }
     if (queue_type == "FollySPSCQueue" && n_adding_threads != 0 && n_adding_threads != 1) {
       throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of pushing threads must 0 or 1 for SPSC queue");
+    }
+    if (n_adding_threads > 0 && nelements % n_adding_threads != 0) {
+      std::ostringstream msg;
+      msg << "# of pushing threads must divide into the # of elements (" << nelements << ") without a remainder";
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, msg.str());
     }
   }
 
@@ -280,6 +316,11 @@ main(int argc, char* argv[])
     }
     if (queue_type == "FollySPSCQueue" && n_removing_threads != 0 && n_removing_threads != 1) {
       throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, "# of popping threads must 0 or 1 for SPSC queue");
+    }
+    if (n_removing_threads > 0 && nelements % n_removing_threads != 0) {
+      std::ostringstream msg;
+      msg << "# of popping threads must divide into the # of elements (" << nelements << ") without a remainder";
+      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, msg.str());
     }
   }
 
@@ -310,50 +351,73 @@ main(int argc, char* argv[])
   push_distribution.reset(new std::uniform_int_distribution<int>(0, 2 * avg_milliseconds_between_pushes));
   pop_distribution.reset(new std::uniform_int_distribution<int>(0, 2 * avg_milliseconds_between_pops));
 
+
   TLOG(TLVL_INFO) << n_adding_threads << " thread(s) pushing " << nelements
                   << " elements between them, each thread has an average time of " << avg_milliseconds_between_pushes
                   << " milliseconds between pushes";
   TLOG(TLVL_INFO) << n_removing_threads << " thread(s) popping " << nelements
                   << " elements between them, each thread has an average time of " << avg_milliseconds_between_pops
                   << " milliseconds between pops";
+  TLOG(TLVL_INFO) << "Queue of type " << queue_type << " has capacity for " << capacity << " elements";
+  
+  int elements_to_begin_with = static_cast<int>(initial_capacity_used * capacity);
 
-/**
- * \todo Add capacity constructor to Queue interface so that this code section
- * makes sense
- *
- * ELF, May 19, 2020
- */
-#if 0
   if (initial_capacity_used > 0) {
+    
+    TLOG(TLVL_INFO) << "Before test officially begins, pushing " << elements_to_begin_with << " elements onto the queue";
+    for (int i_e = 0; i_e < elements_to_begin_with; ++i_e) {
+      queue->push(-1, timeout);
+    }
+    queue_size = elements_to_begin_with;
+    max_queue_size = elements_to_begin_with;
+    TLOG(TLVL_INFO) << "Finished pre-test filling of the queue";
+  }
 
-    int max_capacity = 1000000;
-
-    if (queue->capacity() <= max_capacity) {
-      int elements_to_begin_with =
-          static_cast<int>(initial_capacity_used * queue->capacity());
-      for (int i_e = 0; i_e < elements_to_begin_with; ++i_e) {
-        queue->push(-1, timeout);
-      }
+  if (n_adding_threads > 0 && elements_to_begin_with + nelements > capacity) {
+    std::ostringstream msg;
+    msg << "The number of elements the queue is initially filled with (" << elements_to_begin_with << 
+      ") plus the number of elements which will be pushed onto it (" << nelements << ") exceeds the queue's capacity (" 
+	<< capacity << ")";
+    if (n_removing_threads > 0) {
+      TLOG(TLVL_WARNING) << msg.str();
     } else {
-      std::ostringstream msg;
-      msg << "Since capacity of queue exceeds " << max_capacity
-          << ", the initial fractional used capacity of the queue must be 0";
-      throw dunedaq::appfwk::ParameterDomainIssue(ERS_HERE, msg.str());
+          TLOG(TLVL_ERROR) << msg.str();
+          return 2;
     }
   }
-#endif
 
+  if (n_removing_threads > 0 && nelements > elements_to_begin_with) {
+    std::ostringstream msg;
+    msg << "The number of elements the queue is initially filled with (" << elements_to_begin_with << ") minus the number of elements which will be popped off of it (" << nelements << ") is less than zero";
+
+    if (n_adding_threads > 0) {
+      TLOG(TLVL_WARNING) << msg.str();
+    } else {
+      TLOG(TLVL_ERROR) << msg.str();
+      return 3;
+    }
+  }
+
+  bool spinlock = true;
+  
   std::vector<std::thread> adders;
   std::vector<std::thread> removers;
 
   for (int i = 0; i < n_adding_threads; ++i) {
-    adders.emplace_back(add_things);
+    adders.emplace_back(add_things, std::cref(spinlock));
   }
 
   for (int i = 0; i < n_removing_threads; ++i) {
-    removers.emplace_back(remove_things);
+    removers.emplace_back(remove_things, std::cref(spinlock));
   }
 
+  // 20 ms is the pause Ron used when he originally implemented the
+  // spinlock strategy in his logging package
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  spinlock = false;
+
+  const auto starttime = std::chrono::steady_clock::now();
   for (auto& adder : adders) {
     adder.join();
   }
@@ -361,13 +425,37 @@ main(int argc, char* argv[])
   for (auto& remover : removers) {
     remover.join();
   }
+  const auto total_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - starttime).count();
 
-  TLOG(TLVL_INFO) << "Max queue size during running was " << max_queue_size;
-  TLOG(TLVL_INFO) << "Final queue size at the end of running is " << queue_size;
-  TLOG(TLVL_INFO) << push_attempts << " push attempts made: " << successful_pushes << " successful, " << timeout_pushes
-                  << " timeouts, " << throw_pushes << " exception throws";
-  TLOG(TLVL_INFO) << pop_attempts << " pop attempts made: " << successful_pops << " successful, " << timeout_pops
-                  << " timeouts, " << throw_pops << " exception throws";
+  TLOG(TLVL_INFO) << "\n\nFinal results: ";
+
+  if (enable_max_size_checking) {
+    TLOG(TLVL_INFO) << "Max queue size during running was " << max_queue_size;
+  } else {
+    TLOG(TLVL_INFO) << "Disabled check for max queue size during running";
+  }
+
+  if (n_adding_threads > 0) {
+    TLOG(TLVL_INFO) << "There were " << throw_pushes << " exception throws on push calls";
+    
+    if (enable_per_pushpop_timing) {
+      TLOG(TLVL_INFO) << "There were " << timeout_pushes << " pushes which took longer than the provided timeout of " << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << " ms\n";
+    } else {
+      TLOG(TLVL_INFO) << "Disabled count of slow pushes\n";
+    }    
+  }
+
+  if (n_removing_threads > 0) {
+    TLOG(TLVL_INFO) << "There were " << throw_pops << " exception throws on pop calls";
+    
+    if (enable_per_pushpop_timing) {
+      TLOG(TLVL_INFO) << "There were " << timeout_pops << " pops which took longer than the provided timeout of " << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << " ms\n";
+    } else {
+      TLOG(TLVL_INFO) << "Disabled count of slow pops\n";
+    }    
+  }
+
+  TLOG(TLVL_INFO) << "Total time from start of thread launch to the last thread wrapping up was " << total_time << " ms";
 
   return 0;
 } // NOLINT


### PR DESCRIPTION
The main purpose of this commit is to allow queue_IO_check to test the
behavior of a single thread popping elements off a queue without any
threads pushing on to it at the same time. A couple of other
improvements are also made, however:

* Elimination of obsolete comments

* Clearer output for the tester (e.g., per-thread start time and execution time)

* Basic checks for the internal consistency of input (e.g., it's an
  error if you try performing a pop-only test and request that the queue start out empty)