### PR TITLE
Jcfreeman2/issue106 namedobject doesnt move

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ daq_add_unit_test(FanOutDAQModule_test    appfwk )
 daq_add_unit_test(FollyQueue_test         ers::ers Folly::folly)
 daq_add_unit_test(StdDeQueue_test         ers::ers)
 daq_add_unit_test(ThreadHelper_test       ers::ers)
+daq_add_unit_test(NamedObject_test		  )
 
 ##############################################################################
 

--- a/include/appfwk/NamedObject.hpp
+++ b/include/appfwk/NamedObject.hpp
@@ -23,9 +23,6 @@ public:
    * @brief Named Constructor
    * @param name Name of this object
    */
-  // explicit Named(const std::string& name)
-  //   : name_(name)
-  // {}
   Named() = default;                       ///< Named is default-constructible
   Named(Named const&) = delete;            ///< Named is not copy-constructible
   Named(Named&&) = default;                ///< Named is move-constructible
@@ -34,7 +31,7 @@ public:
   virtual ~Named() = default;              ///< Default virtual destructor
 
   /**
-   * @brief Get the name of this NamedObejct
+   * @brief Get the name of this Named
    * @return The name of this Named
    */
   virtual const std::string& get_name() const = 0;
@@ -62,12 +59,12 @@ public:
 
   /**
    * @brief Get the name of this NamedObejct
-   * @return The name of this Named
+   * @return The name of this NamedObject
    */
   const std::string& get_name() const final { return name_; }
 
 private:
-  const std::string name_;
+  std::string name_;
 };
 
 } // namespace dunedaq::appfwk

--- a/unittest/NamedObject_test.cxx
+++ b/unittest/NamedObject_test.cxx
@@ -1,0 +1,51 @@
+/**
+ * @file Named_test.cxx Named/NamedObject class Unit Tests
+ *
+ * The tests here primarily confirm that the move and copy semantics
+ * are what we expect them to be
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/NamedObject.hpp"
+
+#define BOOST_TEST_MODULE NamedObject_test // NOLINT
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <type_traits>
+
+BOOST_AUTO_TEST_SUITE(NamedObject_test)
+
+BOOST_AUTO_TEST_CASE(Named)
+{
+
+  class DerivesFromNamed : public dunedaq::appfwk::Named {
+    public:
+      explicit DerivesFromNamed(const std::string& name) : myname_(name) {}
+      virtual const std::string& get_name() const { return myname_; };
+    private:
+      std::string myname_;
+  };
+
+  BOOST_REQUIRE( !std::is_copy_constructible_v<DerivesFromNamed> );
+  BOOST_REQUIRE( !std::is_copy_assignable_v<DerivesFromNamed> );
+  BOOST_REQUIRE( std::is_move_constructible_v<DerivesFromNamed> );
+  BOOST_REQUIRE( std::is_move_assignable_v<DerivesFromNamed> );
+}
+
+BOOST_AUTO_TEST_CASE(NamedObject)
+{
+  class DerivesFromNamedObject : public dunedaq::appfwk::NamedObject {
+    // No implementation needed
+  };
+
+  BOOST_REQUIRE( !std::is_copy_constructible_v<DerivesFromNamedObject> );
+  BOOST_REQUIRE( !std::is_copy_assignable_v<DerivesFromNamedObject> );
+  BOOST_REQUIRE( std::is_move_constructible_v<DerivesFromNamedObject> );
+  BOOST_REQUIRE( std::is_move_assignable_v<DerivesFromNamedObject> );
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
More-or-less a cut and paste from what I wrote for Issue #106:

Removed the const qualifier for NamedObject's name_ member so that it's move-assignable,  and added a unit test to test this (as well as its other move/copy semantics). To run the unit test, after you've checked out `jcfreeman2/issue106_namedobject_doesnt_move` and built, just do:
```
./build_daq_software --unittest`
```
and if you look at the tests for NamedObject you shouldn't see any errors. A move assignment error should appear, however, if you (locally!) revert the commit 5b34f59.