### PR TITLE
(more) sensible handling of cetlib plugin errors when creating modules

### DIFF
--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -52,11 +52,72 @@
 
 namespace dunedaq {
 
-namespace appfwk {
+  /**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+  ERS_DECLARE_ISSUE(appfwk,                                                                ///< Namespace
+                    DAQModuleCreationFailed,                                               ///< Type of the Issue
+                    "Failed to create DAQModule " << instance_name << " of type " << plugin_name, ///< Log Message from the issue
+                    ((std::string)plugin_name)((std::string)instance_name)                        ///< Message parameters
+  )
 
-    
+  /**
+ * @brief A generic DAQModule ERS Issue
+ */
+  ERS_DECLARE_ISSUE(appfwk,                 ///< Namespace
+                    GeneralDAQModuleIssue,  ///< Issue class name
+                    " DAQModule: " << name, ///< Message
+                    ((std::string)name)     ///< Message parameters
+  )
 
-/**
+  /**
+ * @brief Generic command ERS Issue
+ */
+  ERS_DECLARE_ISSUE_BASE(appfwk,                        ///< Namespace
+                         CommandIssue,                  ///< Type of the issue
+                         appfwk::GeneralDAQModuleIssue, ///< Base class of the issue
+                         " Command " << cmd,            ///< Log Message from the issue
+                         ((std::string)name),           ///< Base class attributes
+                         ((std::string)cmd)            ///< Attribute of this class
+  )
+
+  /**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+  ERS_DECLARE_ISSUE_BASE(appfwk,                                ///< Namespace
+                         CommandRegistrationFailed,             ///< Type of the Issue
+                         appfwk::CommandIssue,                  ///< Base class of the Issue
+                         "Command registration failed.",        ///< Log Message from the issue
+                         ((std::string)cmd)((std::string)name), ///< Base class attributes
+                         ERS_EMPTY                              ///< Attribute of this class
+  )
+
+  /**
+ * @brief The UnknownCommand DAQModule ERS Issue
+ */
+  ERS_DECLARE_ISSUE_BASE(appfwk,                                ///< Namespace
+                         UnknownCommand,                        ///< Issue class name
+                         appfwk::CommandIssue,                  ///< Base class of the issue
+                         "Command is not recognised",           ///< Log Message from the issue
+                         ((std::string)cmd)((std::string)name), ///< Base class attributes
+                         ERS_EMPTY                              ///< Attribute of this class
+  )
+
+  /**
+ * @brief The CommandFailed DAQModule ERS Issue
+ */
+  ERS_DECLARE_ISSUE_BASE(appfwk,                                ///< Namespace
+                         CommandFailed,                         ///< Type of the Issue
+                         appfwk::CommandIssue,                  ///< Base class of the Issue
+                         "Command Failed. Reason " << reason,   ///< Log Message from the issue
+                         ((std::string)cmd)((std::string)name), ///< Base class attributes
+                         ((std::string)reason)                  ///< Attribute of this class
+  )
+
+  namespace appfwk
+  {
+
+    /**
  * @brief The DAQModule class implementations are a set of code which performs
  * a specific task.
  *
@@ -67,135 +128,89 @@ namespace appfwk {
  * This header also contains the definitions of the Issues that can be
  * thrown by the DAQModule.
  */
-class DAQModule : public NamedObject
-{
-public:
+    class DAQModule : public NamedObject
+    {
+    public:
 
-  using data_t = nlohmann::json;
+      using data_t = nlohmann::json;
 
-    /**
+      /**
    * @brief DAQModule Constructor
    * @param name Name of the DAQModule
    */
-  explicit DAQModule(std::string name)
-    : NamedObject(name)
-  {}
+      explicit DAQModule(std::string name)
+          : NamedObject(name)
+      {}
 
-  /**
-   * @brief      Initializes the module
-   *
-   * Initialisation of the module. Abstract method to be overridden by derived classes.
-   */
-  virtual void init( const data_t& ) = 0;
+      /**
+       * @brief      Initializes the module
+       *
+       * Initialisation of the module. Abstract method to be overridden by derived classes.
+       */
+          virtual void init( const data_t& ) = 0;
 
-  /**
-   * @brief Execute a command in this DAQModule
-   * @param cmd The command from CCM
-   * @param args Arguments for the command from CCM
-   * @return String with detailed status of the command (future).
-   *
-   * execute_command is the single entry point for DAQProcess to pass CCM
-   * commands to DAQModules. The implementation of this function should route
-   * accepted commands to the appropriate functions within the DAQModule.
-   *  Non-accepted commands or failure should return an ERS exception
-   * indicating this result.
-   */
-  void execute_command(const std::string& name, const data_t& data = {});
+          /**
+       * @brief Execute a command in this DAQModule
+       * @param cmd The command from CCM
+       * @param args Arguments for the command from CCM
+       * @return String with detailed status of the command (future).
+       *
+       * execute_command is the single entry point for DAQProcess to pass CCM
+       * commands to DAQModules. The implementation of this function should route
+       * accepted commands to the appropriate functions within the DAQModule.
+       *  Non-accepted commands or failure should return an ERS exception
+       * indicating this result.
+       */
+      void execute_command(const std::string& name, const data_t& data = {});
 
-  std::vector<std::string> get_commands() const;
+      std::vector<std::string> get_commands() const;
 
-  bool has_command(const std::string& name) const;
+      bool has_command(const std::string& name) const;
 
-protected:
+    protected:
 
-  /**
-   * @brief Registers a mdoule command under the name `cmd`.
-   * Returns whether the command was inserted (false meaning that command `cmd` already exists)
-   */
-  template<typename Child>
-  void register_command(const std::string& name, void (Child::*f)(const data_t&));
+      /**
+       * @brief Registers a mdoule command under the name `cmd`.
+       * Returns whether the command was inserted (false meaning that command `cmd` already exists)
+       */
+      template<typename Child>
+      void register_command(const std::string& name, void (Child::*f)(const data_t&));
 
-  DAQModule(DAQModule const&) = delete;            
-  DAQModule(DAQModule&&) = delete;                
-  DAQModule& operator=(DAQModule const&) = delete; 
-  DAQModule& operator=(DAQModule&&) = delete;     
+      DAQModule(DAQModule const&) = delete;
+      DAQModule(DAQModule&&) = delete;
+      DAQModule& operator=(DAQModule const&) = delete;
+      DAQModule& operator=(DAQModule&&) = delete;
 
 
-private:
-  using CommandMap_t = std::map<std::string, std::function<void(const data_t&)>>;
-  CommandMap_t commands_;
+    private:
+      using CommandMap_t = std::map<std::string, std::function<void(const data_t&)>>;
+      CommandMap_t commands_;
 
-};
+    };
 
-/**
- * @brief Load a DAQModule plugin and return a shared_ptr to the contained
- * DAQModule class
- * @param plugin_name Name of the plugin, e.g. DebugLoggingDAQModule
- * @param instance_name Name of the returned DAQModule instance, e.g.
- * DebugLogger1
- * @return shared_ptr to created DAQModule instance
- */
-inline std::shared_ptr<DAQModule>
-makeModule(std::string const& plugin_name, std::string const& instance_name)
-{
-  static cet::BasicPluginFactory bpf("duneDAQModule", "make");
+    /**
+     * @brief Load a DAQModule plugin and return a shared_ptr to the contained
+     * DAQModule class
+     * @param plugin_name Name of the plugin, e.g. DebugLoggingDAQModule
+     * @param instance_name Name of the returned DAQModule instance, e.g.
+     * DebugLogger1
+     * @return shared_ptr to created DAQModule instance
+     */
+    inline std::shared_ptr<DAQModule>
+    makeModule(std::string const& plugin_name, std::string const& instance_name)
+    {
+      static cet::BasicPluginFactory bpf("duneDAQModule", "make");
 
-  return bpf.makePlugin<std::shared_ptr<DAQModule>>(plugin_name, instance_name);
-}
+      std::shared_ptr<DAQModule> mod_ptr;
+      try {
+        mod_ptr = bpf.makePlugin<std::shared_ptr<DAQModule>>(plugin_name, instance_name);
+      } catch (const cet::exception& cexpt) {
+        throw DAQModuleCreationFailed(ERS_HERE, plugin_name, instance_name, cexpt);
+      }
+      return mod_ptr;
+    }
 
 } // namespace appfwk
-
-/**
- * @brief A generic DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE(appfwk,                 ///< Namespace
-                  GeneralDAQModuleIssue,  ///< Issue class name
-                  " DAQModule: " << name, ///< Message
-                  ((std::string)name)     ///< Message parameters
-)
-
-/**
- * @brief Generic command ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                        ///< Namespace
-                       CommandIssue,                  ///< Type of the issue
-                       appfwk::GeneralDAQModuleIssue, ///< Base class of the issue
-                       " Command " << cmd,            ///< Log Message from the issue
-                       ((std::string)name),           ///< Base class attributes
-                       ((std::string)cmd))            ///< Attribute of this class
-
-/**
- * @brief The CommandFailed DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                ///< Namespace
-                       CommandRegistrationFailed,             ///< Type of the Issue
-                       appfwk::CommandIssue,                  ///< Base class of the Issue
-                       "Command registration failed.",        ///< Log Message from the issue
-                       ((std::string)cmd)((std::string)name), ///< Base class attributes
-                       ERS_EMPTY                              ///< Attribute of this class
-)
-
-/**
- * @brief The UnknownCommand DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                ///< Namespace
-                       UnknownCommand,                        ///< Issue class name
-                       appfwk::CommandIssue,                  ///< Base class of the issue
-                       "Command is not recognised",           ///< Log Message from the issue
-                       ((std::string)cmd)((std::string)name), ///< Base class attributes
-                       ERS_EMPTY                              ///< Attribute of this class
-)
-
-/**
- * @brief The CommandFailed DAQModule ERS Issue
- */
-ERS_DECLARE_ISSUE_BASE(appfwk,                                ///< Namespace
-                       CommandFailed,                         ///< Type of the Issue
-                       appfwk::CommandIssue,                  ///< Base class of the Issue
-                       "Command Failed. Reason " << reason,   ///< Log Message from the issue
-                       ((std::string)cmd)((std::string)name), ///< Base class attributes
-                       ((std::string)reason)                  ///< Attribute of this class
-)
 
 
 } // namespace dunedaq

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -53,10 +53,10 @@
 namespace dunedaq {
 
   /**
- * @brief The CommandFailed DAQModule ERS Issue
- */
-  ERS_DECLARE_ISSUE(appfwk,                                                                ///< Namespace
-                    DAQModuleCreationFailed,                                               ///< Type of the Issue
+  * @brief A ERS Issue for DAQModule creation failure
+  */
+  ERS_DECLARE_ISSUE(appfwk,                                                                       ///< Namespace
+                    DAQModuleCreationFailed,                                                      ///< Type of the Issue
                     "Failed to create DAQModule " << instance_name << " of type " << plugin_name, ///< Log Message from the issue
                     ((std::string)plugin_name)((std::string)instance_name)                        ///< Message parameters
   )

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -112,11 +112,6 @@ DAQModuleManager::execute( const dataobj_t& cmd_data ) {
     auto cmd = cmd_data.get<cmd::Command>();
     ERS_INFO("Command id:"<< cmd.id);
 
-    if (cmd_data.contains("waitms")) {
-        int waitms = cmd_data["waitms"];
-        std::this_thread::sleep_for (std::chrono::milliseconds(waitms));
-    }
-
     if ( ! initialized_ ) {
         if ( cmd.id != "init" ) {
             throw DAQModuleManagerNotInitialized(ERS_HERE, cmd.id);


### PR DESCRIPTION
`DAQModule`'s make wrapper now catches the `cet::exception` thrown when the requested plugin is not found and wraps it into an ers issue.