### PR TITLE
Fix #120 by baking TLAs and grafts into a per-schema model file.

### DIFF
--- a/schema/appfwk-cmd-model.jsonnet
+++ b/schema/appfwk-cmd-model.jsonnet
@@ -1,0 +1,17 @@
+// This is a "model" file specific for the "cmd" schema of the appfwk.
+//
+// It's job is to provide the glue between the schema data structure
+// and the structure that the templates expect.  It "bakes" in some
+// information that might otherwise be provided by TLAs or grapfts.
+// Other schema have their own models which will look almost identical
+// to this one.  We "bake" in this repetition in these schema-specific
+// model files in order to simplify what gets exposed to CMake.
+//
+// To customize to a new schema likely one just needs to find the
+// short schema name and replace it in hte import and the "path".
+// Because Jsonent does not allow "computed imports" we can not 
+// parameterize this much shorter.
+
+local model = import "appfwk-model.jsonnet";
+model(import "appfwk-cmd-schema.jsonnet",
+      "dunedaq.appfwk.cmd", ["dunedaq"])

--- a/schema/appfwk-fdc-model.jsonnet
+++ b/schema/appfwk-fdc-model.jsonnet
@@ -1,0 +1,17 @@
+// This is a "model" file specific for the "cmd" schema of the appfwk.
+//
+// It's job is to provide the glue between the schema data structure
+// and the structure that the templates expect.  It "bakes" in some
+// information that might otherwise be provided by TLAs or grapfts.
+// Other schema have their own models which will look almost identical
+// to this one.  We "bake" in this repetition in these schema-specific
+// model files in order to simplify what gets exposed to CMake.
+//
+// To customize to a new schema likely one just needs to find the
+// short schema name and replace it in hte import and the "path".
+// Because Jsonent does not allow "computed imports" we can not 
+// parameterize this much shorter.
+
+local model = import "appfwk-model.jsonnet";
+model(import "appfwk-fdc-schema.jsonnet",
+      "dunedaq.appfwk.fdc", ["dunedaq"])

--- a/schema/appfwk-fdp-model.jsonnet
+++ b/schema/appfwk-fdp-model.jsonnet
@@ -1,0 +1,17 @@
+// This is a "model" file specific for the "cmd" schema of the appfwk.
+//
+// It's job is to provide the glue between the schema data structure
+// and the structure that the templates expect.  It "bakes" in some
+// information that might otherwise be provided by TLAs or grapfts.
+// Other schema have their own models which will look almost identical
+// to this one.  We "bake" in this repetition in these schema-specific
+// model files in order to simplify what gets exposed to CMake.
+//
+// To customize to a new schema likely one just needs to find the
+// short schema name and replace it in hte import and the "path".
+// Because Jsonent does not allow "computed imports" we can not 
+// parameterize this much shorter.
+
+local model = import "appfwk-model.jsonnet";
+model(import "appfwk-fdp-schema.jsonnet",
+      "dunedaq.appfwk.fdp", ["dunedaq"])

--- a/schema/appfwk-model.jsonnet
+++ b/schema/appfwk-model.jsonnet
@@ -1,6 +1,17 @@
+// This is a parameterized model for the templates targetting C++
+// codegen.
+
 local oschema = import "oschema.jsonnet";
 
+local ocpp = import "ocpp.jsonnet";
+
+// Call it with the object schema (eg appfwk-cmd-schema.jsonnet), and
+// a dot-separated path in which the schema is rooted and a ctxpath
+// which will be stripped from the path when doing things in-context
+// such as #include's.
 function(os, path, ctxpath=[]) {
+    lang: ocpp,
+
     // The path/namespace this model "lives" in
     path: oschema.listify(path),
     nspre: oschema.prepath(self.path),

--- a/schema/generate.sh
+++ b/schema/generate.sh
@@ -29,12 +29,8 @@ render () {
     local outhpp="$outdir/${What}.hpp"
     mkdir -p $outdir
     set -x
-    moo -g '/lang:ocpp.jsonnet' \
-        -M $mydir -T $mydir \
-        -A path="dunedaq.appfwk.${name}" \
-        -A ctxpath="dunedaq" \
-        -A os="appfwk-${name}-schema.jsonnet" \
-        render appfwk-model.jsonnet $tmpl \
+    moo -M $mydir -T $mydir \
+        render appfwk-${name}-model.jsonnet $tmpl \
         > $outhpp || exit -1
     set +x
     echo $outhpp


### PR DESCRIPTION
Note, the generated files end up exactly identical as before so this
does not change any code.  It just sets us up for simpler CMake
integration.