### PR TITLE
Ignore moo-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ _deps
 
 #Emacs
 *~
+
+# moo-generated files
+test/src/appfwk/fakedataproducerdaqmodule/Nljs.hpp
+test/src/appfwk/fakedataproducerdaqmodule/Structs.hpp
+test/src/appfwk/fakedataconsumerdaqmodule/Nljs.hpp
+test/src/appfwk/fakedataconsumerdaqmodule/Structs.hpp


### PR DESCRIPTION
This PR adds the autogenerated Structs.hpp and Nljs.hpp files in test/src to `.gitignore`