### PR TITLE
Philiprodrigues/folly queue no spin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ _deps
 
 #Emacs
 *~
+
+# moo-generated files
+test/src/appfwk/fakedataproducerdaqmodule/Nljs.hpp
+test/src/appfwk/fakedataproducerdaqmodule/Structs.hpp
+test/src/appfwk/fakedataconsumerdaqmodule/Nljs.hpp
+test/src/appfwk/fakedataconsumerdaqmodule/Structs.hpp

--- a/include/appfwk/FollyQueue.hpp
+++ b/include/appfwk/FollyQueue.hpp
@@ -62,7 +62,10 @@ public:
   FollyQueue& operator=(FollyQueue&&) = delete;
 
 private:
-  FollyQueueType<T, false> fQueue;
+  // The boolean argument is `MayBlock`, where "block" appears to mean
+  // "make a system call". With `MayBlock` set to false, the queue
+  // just spin-waits, so we want true
+  FollyQueueType<T, true> fQueue;
 };
 
 template<typename T>


### PR DESCRIPTION
This PR changes the `MayBlock` template argument in the folly `DynamicBoundedQueue` from false to true. With the argument set to false, pushes and pops wait by spinning, which is not what we want. With the argument set to true, pushes and pops will wait without using a full CPU (I think the underlying folly implementation spins briefly then waits on a futex). In a test of the fake minidaq app, this change reduces the CPU% from 1200% to 5%