### PR TITLE
Python helper functions for module construction (in python)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appfwk VERSION 2.0.1)
+project(appfwk VERSION 2.0.2)
 
 find_package(daq-cmake REQUIRED )
 

--- a/python/appfwk/utils.py
+++ b/python/appfwk/utils.py
@@ -3,9 +3,22 @@ import moo.otypes
 from dunedaq.env import get_moo_model_path
 moo.otypes.load_types('appfwk-cmd-schema.jsonnet', get_moo_model_path())
 
-import dunedaq.appfwk.cmd as cmd # AddressedCmd, 
+import dunedaq.appfwk.cmd as cmd 
 
 def mspec(inst, plugin, qinfos):
+    """
+    Helper function to create Module Specification objects
+    
+    :param      inst:    Instance
+    :type       inst:    str
+    :param      plugin:  Appfwk Module Plugin name
+    :type       plugin:  str
+    :param      qinfos:  List of dunedaq.appfwk.QueueInfo objects
+    :type       qinfos:  list
+    
+    :returns:   A constructed ModSpec object
+    :rtype:     dunedaq.appfwk.cmd.ModSpec
+    """
     return cmd.ModSpec(inst=inst, plugin=plugin,
             data=cmd.ModInit(
                 qinfos=cmd.QueueInfos(qinfos)
@@ -13,6 +26,17 @@ def mspec(inst, plugin, qinfos):
             )
 
 def mcmd(cmdid, mods):
+    """
+    Helper function to create appfwk's Commands addressed to modules.
+    
+    :param      cmdid:  The coommand id
+    :type       cmdid:  str
+    :param      mods:   List of module name/data structures 
+    :type       mods:   list
+    
+    :returns:   A constructed Command object
+    :rtype:     dunedaq.appfwk.cmd.Command
+    """
     return cmd.Command(
         id=cmd.CmdId(cmdid),
         data=cmd.CmdObj(

--- a/python/appfwk/utils.py
+++ b/python/appfwk/utils.py
@@ -1,0 +1,24 @@
+import moo.otypes
+
+from dunedaq.env import get_moo_model_path
+moo.otypes.load_types('appfwk-cmd-schema.jsonnet', get_moo_model_path())
+
+import dunedaq.appfwk.cmd as cmd # AddressedCmd, 
+
+def mspec(inst, plugin, qinfos):
+    return cmd.ModSpec(inst=inst, plugin=plugin,
+            data=cmd.ModInit(
+                qinfos=cmd.QueueInfos(qinfos)
+                )
+            )
+
+def mcmd(cmdid, mods):
+    return cmd.Command(
+        id=cmd.CmdId(cmdid),
+        data=cmd.CmdObj(
+            modules=cmd.AddressedCmds(
+                cmd.AddressedCmd(match=m, data=o)
+                for m,o in mods
+            )
+        )
+    )

--- a/schema/appfwk-cmd-schema.jsonnet
+++ b/schema/appfwk-cmd-schema.jsonnet
@@ -105,6 +105,17 @@ local cs = {
                 doc="Addressed, module command objects"),
     ], doc="Structure of app-level, non-init command object"), 
 
+    run_number: s.number("RunNumber", dtype="u8",
+                       doc="Run Number"),
+
+    start_params: s.record("StartParams", [
+        s.field("run", self.run_number, doc="Run Number")
+    ]),
+
+    empty_params: s.record("EmptyParams", [
+    ])
+
+
 };
 
 // Output a topologically sorted array.


### PR DESCRIPTION
This PR includes the `mspec` and `mcmd` utility functions to simplify the creation of module spec objects and commands addresses to modules.