### PR TITLE
Re-throw exceptions from the working thread in the thread that calls stop

### DIFF
--- a/unittest/ThreadHelper_test.cxx
+++ b/unittest/ThreadHelper_test.cxx
@@ -27,6 +27,12 @@ do_something(std::atomic<bool>&)
   std::this_thread::sleep_for(std::chrono::seconds(num_seconds));
 }
 
+void
+throw_something(std::atomic<bool>&)
+{
+  throw std::runtime_error("foo!");
+}
+
 std::string test_thread_name;
 std::string actual_thread_name;
 
@@ -121,4 +127,11 @@ BOOST_AUTO_TEST_CASE(abort_checks, *boost::unit_test::depends_on("inappropriate_
   //   dunedaq::appfwk::ThreadHelper umth(do_something);
   //   umth.start_working_thread();
   // }
+}
+
+BOOST_AUTO_TEST_CASE(catch_throw)
+{
+  dunedaq::appfwk::ThreadHelper umth(throw_something);
+  umth.start_working_thread();
+  BOOST_CHECK_THROW(umth.stop_working_thread(), std::runtime_error);
 }


### PR DESCRIPTION
As discussed in #133, exceptions thrown from the working thread in `ThreadHelper` crash the application. I found a possible approach here using `std::exception_ptr`:

https://vorbrodt.blog/2019/03/24/propagate-exceptions-across-threads/

I've implemented this approach here. Any exceptions thrown in the working thread are rethrown in the thread that calls `stop_working_thread()`. I'm not very familiar with this technique, so more pairs of eyes would be useful. If we decide to go with the general approach, I will add more documentation.