### PR TITLE
Add queue_inst function to map module-internal endpoint name to application-wide queue 'instance' name

### DIFF
--- a/include/appfwk/DAQModuleHelper.hpp
+++ b/include/appfwk/DAQModuleHelper.hpp
@@ -31,6 +31,11 @@ queue_index(const nlohmann::json& iniobj, std::vector<std::string> required = {}
 cmd::QueueInfos
 queue_infos(const nlohmann::json& iniobj);
 
+std::string queue_inst(const nlohmann::json& iniobj, const std::string& name)
+{
+  return queue_index(iniobj, {name})[name].inst;
+}
+  
 } // namespace appfwk
 
 } // namespace dunedaq


### PR DESCRIPTION
Add `queue_inst` function to `DAQModuleHelper`. Allows creators of `DAQ(Source|Sink)` to write:

`new DAQSource<T>(queue_inst(iniobj, name));`

instead of looping over the json object passed to `init`.