### PR TITLE
Primitive RESTful API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(appfwk VERSION 2.2.2)
 
-find_package(daq-cmake REQUIRED )
+find_package(daq-cmake REQUIRED)
 
 daq_setup_environment()
 
@@ -14,38 +14,41 @@ find_package(ers REQUIRED)
 find_package(cmdlib REQUIRED)
 find_package(rcif REQUIRED)
 find_package(opmonlib REQUIRED)
-find_package(nlohmann_json REQUIRED )
+find_package(nlohmann_json REQUIRED)
+find_package(Pistache REQUIRED)
 
-set(APPFWK_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging Folly::folly cmdlib::cmdlib rcif::rcif opmonlib::opmonlib nlohmann_json::nlohmann_json pthread)
+set(APPFWK_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging Folly::folly cmdlib::cmdlib rcif::rcif opmonlib::opmonlib nlohmann_json::nlohmann_json pthread pistache_shared)
 
-daq_codegen( *.jsonnet DEP_PKGS rcif cmdlib TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen(*.jsonnet DEP_PKGS rcif cmdlib TEMPLATES Structs.hpp.j2 Nljs.hpp.j2)
 
 ##############################################################################
 # Main library
-daq_add_library(QueueRegistry.cpp DAQModule*.cpp Application.cpp LINK_LIBRARIES ${APPFWK_DEPENDENCIES})
+daq_add_library(QueueRegistry.cpp DAQModule*.cpp Application.cpp rest/Api.cpp LINK_LIBRARIES ${APPFWK_DEPENDENCIES})
 
 # ##############################################################################
 # Applications
-daq_add_application( daq_application daq_application.cxx LINK_LIBRARIES appfwk )
+daq_add_application(daq_application daq_application.cxx LINK_LIBRARIES appfwk)
 
 # ##############################################################################
 # Test plugins
-daq_add_plugin( DummyModule		  duneDAQModule TEST LINK_LIBRARIES appfwk )
+daq_add_plugin(DummyModule duneDAQModule TEST LINK_LIBRARIES appfwk)
 
 # Test applications
-daq_add_application( queue_IO_check queue_IO_check.cxx TEST LINK_LIBRARIES appfwk )
+daq_add_application(queue_IO_check queue_IO_check.cxx TEST LINK_LIBRARIES appfwk)
 
 
 # ##############################################################################
 # Unit tests
 
-daq_add_unit_test(DAQModule_test          LINK_LIBRARIES appfwk )
-daq_add_unit_test(DAQSink_DAQSource_test  LINK_LIBRARIES appfwk )
+daq_add_unit_test(DAQModule_test          LINK_LIBRARIES appfwk)
+daq_add_unit_test(DAQSink_DAQSource_test  LINK_LIBRARIES appfwk)
 daq_add_unit_test(FollyQueue_test         LINK_LIBRARIES ers::ers Folly::folly)
-daq_add_unit_test(Interruptible_test         LINK_LIBRARIES appfwk)
+daq_add_unit_test(Interruptible_test      LINK_LIBRARIES appfwk)
+daq_add_unit_test(RestApi_test            LINK_LIBRARIES appfwk)
 daq_add_unit_test(StdDeQueue_test         LINK_LIBRARIES ers::ers)
 daq_add_unit_test(ThreadHelper_test       LINK_LIBRARIES ers::ers)
 daq_add_unit_test(NamedObject_test        )
+daq_add_unit_test(StateObject_test        )
 
 ##############################################################################
 

--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -72,7 +72,7 @@ main(int argc, char* argv[])
 
   // Create the Application
   appfwk::Application app(
-    args.app_name, args.partition_name, args.command_facility_plugin_name, args.info_service_plugin_name);
+    args.app_name, args.partition_name, args.rest_api, args.command_facility_plugin_name, args.info_service_plugin_name);
 
   app.init();
   app.run(run_marker);

--- a/include/appfwk/CommandLineInterpreter.hpp
+++ b/include/appfwk/CommandLineInterpreter.hpp
@@ -54,6 +54,7 @@ public:
       ("name,n", bpo::value<std::string>()->required(), "Application name")
       ("partition,p", bpo::value<std::string>()->default_value("global"), "Partition name")
       ("commandFacility,c", bpo::value<std::string>()->required(), "CommandFacility URI")
+      ("rest-api,r", bpo::value<std::uint32_t>()->default_value(0), "REST API Port")
       ("informationService,i", bpo::value<std::string>()->default_value("stdout://flat"), "Information Service URI")
       ("help,h", "produce help message");
 
@@ -81,6 +82,7 @@ public:
     output.app_name = vm["name"].as<std::string>();
     output.partition_name = vm["partition"].as<std::string>();
     output.command_facility_plugin_name = vm["commandFacility"].as<std::string>();
+    output.rest_api = vm["rest-api"].as<std::uint32_t>();
     output.info_service_plugin_name = vm["informationService"].as<std::string>();
     output.is_valid = true;
     return output;
@@ -91,6 +93,7 @@ public:
   std::string app_name;
   std::string partition_name;
   std::string command_facility_plugin_name; ///< Name of the CommandFacility plugin to load
+  std::uint32_t rest_api;
   std::string info_service_plugin_name; ///< Name of the InfoService plugin to load
 
   std::vector<std::string> other_options; ///< Any other options which were passed and not recognized

--- a/include/appfwk/DAQModuleManager.hpp
+++ b/include/appfwk/DAQModuleManager.hpp
@@ -54,6 +54,7 @@ class DAQModuleManager
 {
 public:
   using dataobj_t = nlohmann::json;
+  typedef std::map<std::string, std::shared_ptr<DAQModule>> DAQModuleMap_t; ///< DAQModules indexed by name
 
   DAQModuleManager();
 
@@ -63,20 +64,21 @@ public:
   void execute(const dataobj_t& cmd_data);
 
   // Gather statistics from modules
-  void gather_stats(opmonlib::InfoCollector& ic, int level); 
+  void gather_stats(opmonlib::InfoCollector& ic, int level);
+
+  DAQModuleMap_t get_modules() { return m_module_map; }
 
 protected:
-  typedef std::map<std::string, std::shared_ptr<DAQModule>> DAQModuleMap_t; ///< DAQModules indexed by name
 
-    void initialize( const dataobj_t& data );
-    void init_queues( const app::QueueSpecs& qspecs );
-    void init_modules( const app::ModSpecs& mspecs );
+  void initialize( const dataobj_t& data );
+  void init_queues( const app::QueueSpecs& qspecs );
+  void init_modules( const app::ModSpecs& mspecs );
 
-    void dispatch_one_match_only(cmdlib::cmd::CmdId id, const dataobj_t& data );
-    void dispatch_after_merge(cmdlib::cmd::CmdId id, const dataobj_t& data );
+  void dispatch_one_match_only(cmdlib::cmd::CmdId id, const dataobj_t& data );
+  void dispatch_after_merge(cmdlib::cmd::CmdId id, const dataobj_t& data );
 
 private:
-    std::vector<std::string> get_modnames_by_cmdid(cmdlib::cmd::CmdId id);
+  std::vector<std::string> get_modnames_by_cmdid(cmdlib::cmd::CmdId id);
 
   bool m_initialized;
 

--- a/include/appfwk/DAQModuleManager.hpp
+++ b/include/appfwk/DAQModuleManager.hpp
@@ -66,6 +66,8 @@ public:
   // Gather statistics from modules
   void gather_stats(opmonlib::InfoCollector& ic, int level);
 
+  std::vector<dataobj_t> gather_history() { return m_command_history; }
+
   DAQModuleMap_t get_modules() { return m_module_map; }
 
 protected:
@@ -83,6 +85,8 @@ private:
   bool m_initialized;
 
   DAQModuleMap_t m_module_map;
+
+  std::vector<dataobj_t> m_command_history;
 };
 
 } // namespace appfwk

--- a/include/appfwk/NamedObject.hpp
+++ b/include/appfwk/NamedObject.hpp
@@ -51,12 +51,6 @@ public:
     : m_name(name)
   {}
 
-  NamedObject(NamedObject const&) = delete;            ///< NamedObject is not copy-constructible
-  NamedObject(NamedObject&&) = default;                ///< NamedObject is move-constructible
-  NamedObject& operator=(NamedObject const&) = delete; ///< NamedObject is not copy-assignable
-  NamedObject& operator=(NamedObject&&) = default;     ///< NamedObject is move-assignable
-  virtual ~NamedObject() = default;                    ///< Default virtual destructor
-
   /**
    * @brief Get the name of this NamedObejct
    * @return The name of this NamedObject

--- a/include/appfwk/StateObject.hpp
+++ b/include/appfwk/StateObject.hpp
@@ -1,0 +1,59 @@
+/**
+ * @file StateObject.hpp Class that describes an object with a state
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef CMDLIB_INCLUDE_APPFWK_STATEOBJECT_HPP_
+#define CMDLIB_INCLUDE_APPFWK_STATEOBJECT_HPP_
+
+#include <mutex>
+#include <string>
+
+namespace dunedaq::appfwk {
+
+/**
+ * @brief Interface needed by commanded objects in the DAQ
+ */
+class StateObject
+{
+public:
+
+  /**
+   * @brief StateObject Constructor
+   * @param initial_state The initial state of this object
+   */
+  StateObject(const std::string& initial_state): m_state(initial_state)
+  {}
+
+  StateObject(StateObject const&) = delete;            ///< StateObject is not copy-constructible
+  StateObject(StateObject&&) = default;                ///< StateObject is move-constructible
+  StateObject& operator=(StateObject const&) = delete; ///< StateObject is not copy-assignable
+  StateObject& operator=(StateObject&&) = default;     ///< StateObject is move-assignable
+  virtual ~StateObject() = default;                    ///< Default virtual destructor
+
+  /**
+   * Get state of this object.
+   * Thread safe
+   */
+  void  set_state(std::string s) {
+     const std::lock_guard<std::mutex> lock(m_state_mutex);
+     m_state = s;
+  } 
+  /**
+   * Set new state on this object.
+   * Thread safe
+   */
+  std::string get_state() {
+    const std::lock_guard<std::mutex> lock(m_state_mutex);
+    return m_state ;
+  }
+private:
+  std::mutex m_state_mutex;
+  std::string m_state;
+};
+
+} // namespace dunedaq::appfwk
+
+#endif // CMDLIB_INCLUDE_APPFWK_STATEOBJECT_HPP__

--- a/include/appfwk/rest/Api.hpp
+++ b/include/appfwk/rest/Api.hpp
@@ -135,7 +135,7 @@ private:
    */
   void handle_get_root(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
   /**
-   * @brief Function handling 'GET /healthz'
+   * @brief Function handling 'GET /api/v0/healthz'
    */
   void handle_get_healthz(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
 

--- a/include/appfwk/rest/Api.hpp
+++ b/include/appfwk/rest/Api.hpp
@@ -93,6 +93,8 @@ public:
    */
   bool start_failed() { return m_start_failed; }
 
+  Pistache::Port get_port() { return m_port; }
+
   /**
    * @brief Add and remove routes.
    * These functions forward directly to the pistache router, and do some extra bookkeeping

--- a/include/appfwk/rest/Api.hpp
+++ b/include/appfwk/rest/Api.hpp
@@ -151,6 +151,10 @@ private:
    * @brief Function handling 'GET /api/v0/modules'
    */
   void handle_get_modules(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
+  /**
+   * @brief Function handling 'GET /api/v0/commands/history'
+   */
+  void handle_get_commands_history(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
 
   /**
    * Blocking call that starts the API and serves requests.

--- a/include/appfwk/rest/Api.hpp
+++ b/include/appfwk/rest/Api.hpp
@@ -10,6 +10,7 @@
 
 #include "appfwk/NamedObject.hpp"
 #include "appfwk/StateObject.hpp"
+#include "appfwk/DAQModuleManager.hpp"
 #include "ers/Issue.hpp"
 #include "nlohmann/json.hpp"
 #include "structs.hpp"
@@ -51,7 +52,7 @@ class Api
 public:
   /**
    * Construct a new API on the given port.
-   * The port is not opened at construction time
+   * The port is not opened at construction time.
    * @param port the port to listen on
    */
   Api(std::uint16_t /*port*/);
@@ -63,14 +64,20 @@ public:
   Api& operator=(Api&&) = default;       ///< Api is move-assignable
 
   /**
-   * @brief register elements needed to serve z pages
+   * @brief Register elements needed to serve z pages.
    */
   void register_zpages(std::string /*name*/, appfwk::StateObject*);
 
   /**
+   * Register the DAQModuleManager that will be used
+   * to query for module info.
+   */
+  void register_modulemanager(appfwk::DAQModuleManager*);
+
+  /**
    * @brief Start this API.
    * 
-   * Spawns a separate thread that will serve incoming connections
+   * Spawns a separate thread that will serve incoming connections.
    * 
    * @throws RestApiAlreadyRunning if start() was called and succeeded before
    * @throws RestApiStartFailed if the api failed to start
@@ -113,6 +120,8 @@ private:
   std::string m_app_name;
   // The StateObject this API will call get_state() on
   appfwk::StateObject* m_state_obj;
+  // The DAQModuleManager the API will use to serve /modules
+  appfwk::DAQModuleManager* m_module_manager;
   // The port number this API will serve requests on
   Pistache::Port m_port;
   // The address this API will serve requests on
@@ -138,6 +147,10 @@ private:
    * @brief Function handling 'GET /api/v0/healthz'
    */
   void handle_get_healthz(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
+  /**
+   * @brief Function handling 'GET /api/v0/modules'
+   */
+  void handle_get_modules(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
 
   /**
    * Blocking call that starts the API and serves requests.

--- a/include/appfwk/rest/Api.hpp
+++ b/include/appfwk/rest/Api.hpp
@@ -1,0 +1,151 @@
+/**
+ * @file API.hpp RESTful API for DAQ Applications
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef CMDLIB_INCLUDE_REST_API_HPP_
+#define CMDLIB_INCLUDE_REST_API_HPP_
+
+#include "appfwk/NamedObject.hpp"
+#include "appfwk/StateObject.hpp"
+#include "ers/Issue.hpp"
+#include "nlohmann/json.hpp"
+#include "structs.hpp"
+
+#include <pistache/http.h>
+#include <pistache/http_header.h>
+#include <pistache/description.h>
+#include <pistache/router.h>
+#include <pistache/endpoint.h>
+#include <pistache/client.h>
+#include <pistache/mime.h>
+
+#include <thread>
+#include <stdint.h>
+#include <set>
+
+namespace dunedaq {
+
+ERS_DECLARE_ISSUE(rest,
+                  RestApiStartFailed,
+                  "REST API failed to start on port " << port,
+                  ((std::uint16_t) port)
+)
+ERS_DECLARE_ISSUE(rest,
+                  RestApiStarted,
+                  "REST API listening on port " << port,
+                  ((std::uint16_t) port)
+)
+ERS_DECLARE_ISSUE(rest,
+                  RestApiAlreadyRunning,
+                  "REST API already running on port " << port,
+                  ((std::uint16_t) port)
+)
+
+namespace rest {
+
+class Api
+{
+public:
+  /**
+   * Construct a new API on the given port.
+   * The port is not opened at construction time
+   * @param port the port to listen on
+   */
+  Api(std::uint16_t /*port*/);
+  ~Api();
+  Api() = delete;                        ///< Api is not default-constructible
+  Api(Api const&) = delete;              ///< Api is not copy-constructible
+  Api(Api&&) = default;                  ///< Api is move-constructible
+  Api& operator=(Api const&) = delete;   ///< Api is not copy-assignable
+  Api& operator=(Api&&) = default;       ///< Api is move-assignable
+
+  /**
+   * @brief register elements needed to serve z pages
+   */
+  void register_zpages(std::string /*name*/, appfwk::StateObject*);
+
+  /**
+   * @brief Start this API.
+   * 
+   * Spawns a separate thread that will serve incoming connections
+   * 
+   * @throws RestApiAlreadyRunning if start() was called and succeeded before
+   * @throws RestApiStartFailed if the api failed to start
+   */
+  void start();
+
+  /**
+   * @brief Stops the API.
+   */
+  void stop();
+
+  /**
+   * Denotes whether this application has successfully started
+   * after a call to start()
+   */
+  bool is_started() { return m_started; }
+  /**
+   * Denotes whether this application has failed to start
+   * after a call to start()
+   */
+  bool start_failed() { return m_start_failed; }
+
+  /**
+   * @brief Add and remove routes.
+   * These functions forward directly to the pistache router, and do some extra bookkeeping
+   */
+  void register_get(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void register_post(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void register_put(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void register_patch(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void register_delete(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void register_options(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void register_head(const std::string &resource, Pistache::Rest::Route::Handler handler);
+  void unregister(Pistache::Http::Method method, const std::string &resource);
+
+private:
+  // The name of the DAQ Application this API runs for
+  std::string m_app_name;
+  // The StateObject this API will call get_state() on
+  appfwk::StateObject* m_state_obj;
+  // The port number this API will serve requests on
+  Pistache::Port m_port;
+  // The address this API will serve requests on
+  Pistache::Address m_address;
+  // Wether this API already successfully started
+  bool m_started;
+  // Wether the last start() produced an error
+  bool m_start_failed;
+  // Pistache endpoint that wraps m_address
+  std::shared_ptr<Pistache::Http::Endpoint> m_http_endpoint;
+  // Pistache router
+  Pistache::Rest::Router m_router;
+  // Internal list of registered routes in m_router
+  std::set<std::string> m_routes;
+  // Thread that runs the API server
+  std::thread m_server_thread;
+
+  /**
+   * @brief Function handling 'GET /'
+   */
+  void handle_get_root(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
+  /**
+   * @brief Function handling 'GET /healthz'
+   */
+  void handle_get_healthz(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter response);
+
+  /**
+   * Blocking call that starts the API and serves requests.
+   * Used by start()
+   * 
+   * @throws RestApiStartFailed if the api failed to start
+   */
+  void serve(); 
+};
+
+} // namespace rest
+} // namespace dunedaq
+#endif // CMDLIB_INCLUDE_REST_API_HPP_

--- a/include/appfwk/rest/structs.hpp
+++ b/include/appfwk/rest/structs.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file structs.hpp RESTful API request and response body types
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef CMDLIB_INCLUDE_REST_API_STRUCTS_HPP_
+#define CMDLIB_INCLUDE_REST_API_STRUCTS_HPP_
+
+#include "nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+namespace dunedaq::rest {
+
+struct HealthZReply {
+  std::string name;
+  std::string state;
+};
+
+// to_json and from_json functions must be inline
+// https://github.com/nlohmann/json/issues/542#issuecomment-290665546
+inline void to_json(json& j, const HealthZReply& p) {
+  j = json{{"name", p.name}, {"state", p.state}};
+}
+
+inline void from_json(const json& j, HealthZReply& p) {
+  j.at("name").get_to(p.name);
+  j.at("state").get_to(p.state);
+}
+
+} // namespace dunedaq::rest
+#endif // CMDLIB_INCLUDE_REST_API_STRUCTS_HPP_

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -33,6 +33,7 @@ Application::init()
   m_cmd_fac->set_commanded(*this, get_name());
   m_info_mgr.set_provider(*this);
   m_rest_api.register_zpages(get_name(), (StateObject*)this);
+  m_rest_api.register_modulemanager(&m_mod_mgr);
   m_rest_api.start();
   m_initialized = true;
 }

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -19,6 +19,8 @@
 
 #include "logging/Logging.hpp"
 
+#include "nlohmann/json.hpp"
+
 #include <map>
 #include <regex>
 #include <string>
@@ -234,6 +236,12 @@ DAQModuleManager::execute(const dataobj_t& cmd_data)
 
   auto cmd = cmd_data.get<cmdlib::cmd::Command>();
   TLOG_DEBUG(1) <<"Command id:" << cmd.id;
+
+  // cmd_data's content will be freed after the next command is received
+  // nlohmann::json does not have deep-copy functionality, so we
+  // take a copy
+  nlohmann::json j = nlohmann::json::parse(cmd_data.dump());
+  m_command_history.push_back(j);
 
   if (!m_initialized) {
     if (cmd.id != "init") {

--- a/src/rest/Api.cpp
+++ b/src/rest/Api.cpp
@@ -33,7 +33,7 @@ Api::Api(std::uint16_t port)
   register_get("/", Pistache::Rest::Routes::bind(&Api::handle_get_root, this));
   // healthz will always respond
   // even if register_zpages() has not been called
-  register_get("/healthz", Pistache::Rest::Routes::bind(&Api::handle_get_healthz, this));
+  register_get("/api/v0/healthz", Pistache::Rest::Routes::bind(&Api::handle_get_healthz, this));
 }
 
 Api::~Api()

--- a/src/rest/Api.cpp
+++ b/src/rest/Api.cpp
@@ -1,0 +1,210 @@
+/**
+ * @file Api.cpp RESTful API for DAQ Applications
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/rest/Api.hpp"
+#include "cmdlib/CommandedObject.hpp"
+#include "logging/Logging.hpp"
+
+#include <stdint.h>
+
+using json = nlohmann::json;
+
+namespace dunedaq {
+namespace rest {
+
+Api::Api(std::uint16_t port)
+  : m_port(port), m_address{ Pistache::Ipv4::any(), m_port }
+  , m_http_endpoint{ std::make_shared<Pistache::Http::Endpoint>( m_address ) }
+  , m_started(0), m_start_failed(0)
+{
+  auto opts = Pistache::Http::Endpoint::options()
+    .threads(1)
+    .maxRequestSize(15728640) // 15MB
+    .maxResponseSize(1048576) // 1MB 
+    .flags(Pistache::Tcp::Options::ReuseAddr)
+    .flags(Pistache::Tcp::Options::ReusePort);
+  m_http_endpoint->init(opts);
+
+  register_get("/", Pistache::Rest::Routes::bind(&Api::handle_get_root, this));
+  // healthz will always respond
+  // even if register_zpages() has not been called
+  register_get("/healthz", Pistache::Rest::Routes::bind(&Api::handle_get_healthz, this));
+}
+
+Api::~Api()
+{
+  stop();
+}
+
+void
+Api::register_zpages(std::string name, appfwk::StateObject* stated)
+{
+  m_app_name = name;
+  m_state_obj = stated;
+}
+
+void
+Api::start()
+{
+  if (m_started) {
+    throw RestApiAlreadyRunning(ERS_HERE, m_port);
+  }
+  // any routes added after m_router.handler() will not work
+  m_http_endpoint->setHandler(m_router.handler());
+  m_server_thread = std::thread(&Api::serve, this);
+  // determine the actually open endpoint port
+  // this will always equal m_port except when m_port = 0
+  auto realPort = m_http_endpoint->getPort();
+  while (realPort == 0 && !m_start_failed)
+  {
+    // unfortunatuly we can't seem to open the listener first 
+    // and _then_ do the blocking call to pistache's .serve()
+    usleep(100);
+    realPort = m_http_endpoint->getPort();
+  }
+  // wait for api to be started
+  do
+  {
+    usleep(100);
+  } while (!m_started && !m_start_failed);
+  usleep(100); // for good measure...
+
+  // throw if serve() instantly failed
+  // e.g. can't open port
+  if (m_start_failed) {
+    throw RestApiStartFailed(ERS_HERE, m_port);
+  }
+  
+  ers::info(RestApiStarted(ERS_HERE, realPort));
+}
+
+void
+Api::serve()
+{
+  try {
+    m_started = 1;
+    m_http_endpoint->serve(); // blocking call
+  }
+  catch(std::exception& ex) {
+    m_start_failed = 1;
+    ers::error(RestApiStartFailed(ERS_HERE, m_port, ex));
+    m_http_endpoint->shutdown();
+  }
+}
+
+void
+Api::stop()
+{
+  m_http_endpoint->shutdown();
+  if (m_server_thread.joinable()) {
+    m_server_thread.join();
+  }
+  m_started = 0;
+  m_start_failed = 0;
+}
+
+void
+Api::handle_get_root([[maybe_unused]] const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
+{
+  json j;
+  j["routes"] = m_routes;
+  response.headers().add<Pistache::Http::Header::ContentType>(MIME(Application, Json));
+  response.send(Pistache::Http::Code::Ok, j.dump(2));
+}
+
+void
+Api::handle_get_healthz([[maybe_unused]] const Pistache::Rest::Request& request, Pistache::Http::ResponseWriter response)
+{
+  auto c = Pistache::Http::Code::Ok;
+  HealthZReply result;
+
+  // if the name is not set, we're not healthy
+  if (m_app_name.empty()) {
+    c = Pistache::Http::Code::Service_Unavailable;
+  }
+  result.name = m_app_name;
+
+  // if there is no StateObject to query state from, we're not healthy
+  if (m_state_obj) {
+    result.state = m_state_obj->get_state();
+  } else {
+    c = Pistache::Http::Code::Service_Unavailable;
+  }
+
+  // if there is no state or state is NONE, we're not healthy
+  if (result.state.empty() || result.state == "NONE") {
+    c = Pistache::Http::Code::Service_Unavailable;
+  }
+
+  // convert to json
+  json j = result;
+  
+  // send json
+  response.headers().add<Pistache::Http::Header::ContentType>(MIME(Application, Json));
+  response.send(c, j.dump(2));
+}
+
+void
+Api::register_get(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Get(m_router, resource, handler);
+  m_routes.insert("GET " + resource);
+}
+
+void
+Api::register_post(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Post(m_router, resource, handler);
+  m_routes.insert("POST " + resource);
+}
+
+void
+Api::register_put(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Put(m_router, resource, handler);
+  m_routes.insert("PUT " + resource);
+}
+
+void
+Api::register_patch(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Patch(m_router, resource, handler);
+  m_routes.insert("PATCH " + resource);
+}
+
+void
+Api::register_delete(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Delete(m_router, resource, handler);
+  m_routes.insert("DELETE " + resource);
+}
+
+void
+Api::register_options(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Options(m_router, resource, handler);
+  m_routes.insert("OPTIONS " + resource);
+}
+
+void
+Api::register_head(const std::string &resource, Pistache::Rest::Route::Handler handler)
+{
+  Pistache::Rest::Routes::Head(m_router, resource, handler);
+  m_routes.insert("HEAD " + resource);
+}
+
+void
+Api::unregister(Pistache::Http::Method method, const std::string &resource)
+{
+  Pistache::Rest::Routes::Remove(m_router, method, resource);
+  m_routes.erase(std::string(Pistache::Http::methodString(method)) + " " + resource);
+}
+
+
+} // namespace rest
+} // namespace dunedaq

--- a/src/rest/Api.cpp
+++ b/src/rest/Api.cpp
@@ -67,6 +67,7 @@ Api::start()
     usleep(100);
     realPort = m_http_endpoint->getPort();
   }
+  m_port = realPort;
   // wait for api to be started
   do
   {

--- a/unittest/NamedObject_test.cxx
+++ b/unittest/NamedObject_test.cxx
@@ -1,5 +1,5 @@
 /**
- * @file Named_test.cxx Named/NamedObject class Unit Tests
+ * @file NamedObject_test.cxx Named/NamedObject class Unit Tests
  *
  * The tests here primarily confirm that the move and copy semantics
  * are what we expect them to be

--- a/unittest/RestApi_test.cxx
+++ b/unittest/RestApi_test.cxx
@@ -48,6 +48,7 @@ BOOST_AUTO_TEST_CASE(RestApi)
     api.start();
     BOOST_TEST_REQUIRE(api.is_started());
     BOOST_TEST_REQUIRE(!api.start_failed());
+    BOOST_TEST_REQUIRE(api.get_port() != 0);
   } catch (const dunedaq::rest::RestApiStartFailed& ex) {
     BOOST_TEST_REQUIRE(false, "Test failure: unexpected API Start exception thrown");
   } catch (...) { // NOLINT

--- a/unittest/RestApi_test.cxx
+++ b/unittest/RestApi_test.cxx
@@ -1,0 +1,88 @@
+/**
+ * @file Api_test.cxx Api class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/rest/Api.hpp"
+
+#define BOOST_TEST_MODULE RestApi_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include <string>
+#include <type_traits>
+
+BOOST_AUTO_TEST_SUITE(RestApi_test)
+
+BOOST_AUTO_TEST_CASE(RestApi)
+{
+
+  BOOST_REQUIRE(!std::is_copy_constructible_v<dunedaq::rest::Api>);
+  BOOST_REQUIRE(!std::is_copy_assignable_v<dunedaq::rest::Api>);
+  BOOST_REQUIRE(std::is_move_constructible_v<dunedaq::rest::Api>);
+  BOOST_REQUIRE(std::is_move_assignable_v<dunedaq::rest::Api>);
+
+  // RestApi fails on permission errors
+  auto invalidport = dunedaq::rest::Api(1);
+  try {
+    invalidport.start();
+    BOOST_TEST_REQUIRE(false, "Test failure: starting API on port 1 did not throw exception");
+  } catch (const dunedaq::rest::RestApiStartFailed& ex) {
+    BOOST_TEST_REQUIRE(true, "API fails to open port 1");
+  }
+  // RestApis can be stopped even when they didn't start properly
+  try {
+    invalidport.stop();
+    BOOST_TEST_REQUIRE(!invalidport.is_started());
+    BOOST_TEST_REQUIRE(!invalidport.start_failed());
+  } catch (...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected exception thrown while stopping API");
+  }
+
+  // RestApi can open on port 0 (random port)
+  auto api = dunedaq::rest::Api(0);
+  try {
+    api.start();
+    BOOST_TEST_REQUIRE(api.is_started());
+    BOOST_TEST_REQUIRE(!api.start_failed());
+  } catch (const dunedaq::rest::RestApiStartFailed& ex) {
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected API Start exception thrown");
+  } catch (...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected exception thrown while starting API");
+  }
+
+  // RestApi cannot be started twice
+  try {
+    api.start();
+    BOOST_TEST_REQUIRE(false, "Test failure: starting API twice did not throw exception");
+  } catch (const dunedaq::rest::RestApiAlreadyRunning& ex) {
+    BOOST_TEST_REQUIRE(true, "API refuses to open twice");
+  } catch (...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected exception thrown while starting API twice");
+  }
+
+  // RestApis can be stopped
+  try {
+    api.stop();
+    BOOST_TEST_REQUIRE(!api.is_started());
+    BOOST_TEST_REQUIRE(!api.start_failed());
+  } catch (...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: unexpected exception thrown while stopping API");
+  }
+
+  std::cout << "am here" << std::endl;
+
+  // a started API auto-stops
+  try {
+    auto unloved = new dunedaq::rest::Api(0);
+    unloved->start();
+    delete unloved;
+  } catch (...) { // NOLINT
+    BOOST_TEST_REQUIRE(false, "Test failure: API cannot handle implicit close");
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/StateObject_test.cxx
+++ b/unittest/StateObject_test.cxx
@@ -1,0 +1,49 @@
+/**
+ * @file StateObject_test.cxx StateObject class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/StateObject.hpp"
+
+#define BOOST_TEST_MODULE StateObject_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include <string>
+#include <type_traits>
+
+BOOST_AUTO_TEST_SUITE(StateObject_test)
+
+BOOST_AUTO_TEST_CASE(StateObject)
+{
+  class DerivesFromStateObject : public dunedaq::appfwk::StateObject
+  {
+    // No implementation needed
+  };
+
+  BOOST_REQUIRE(!std::is_copy_constructible_v<DerivesFromStateObject>);
+  BOOST_REQUIRE(!std::is_copy_assignable_v<DerivesFromStateObject>);
+  BOOST_REQUIRE(!std::is_move_constructible_v<DerivesFromStateObject>);
+  BOOST_REQUIRE(!std::is_move_assignable_v<DerivesFromStateObject>);
+
+  // StateObject correctly implements the initial state
+  auto obj = dunedaq::appfwk::StateObject("none");
+  BOOST_REQUIRE(obj.get_state() == "none");
+
+  // StateObject correctly sets a new state
+  obj.set_state("newstate");
+  BOOST_REQUIRE(obj.get_state() == "newstate");
+
+  // set_state works more than one time
+  obj.set_state("newstate2");
+  BOOST_REQUIRE(obj.get_state() == "newstate2");
+
+  // StateObject can have an empty string for state
+  auto obj2 = dunedaq::appfwk::StateObject("");
+  BOOST_REQUIRE(obj2.get_state() == "");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change implements a basic RESTful API in appfwk.

A new class `dunedaq::rest::Api` has been created. 
It does not (yet) use the built-in OpenAPI documentation generator that is demonstrated [here](https://gitlab.eecs.umich.edu/basaksum/vc-qc/blob/0a2b8d55c432e5b584688250ae66e4f86d841915/pistache/examples/rest_description.cc). Rather it exposes more naive functionality that allows developers to associate a method+url (e.g. `GET /api/v0/abc`) to a handler function.

`dunedaq::appfwk::Application` creates an instance of this API and handles initialization. It is also demonstrates how other code areas in a DAQ application can enrich the API with more data and endpoints.

As a first version, it merely implements a basic z page `/api/v0/healthz`, another remnant of Borg.
Their usefulness is demonstrated [here](https://vimeo.com/173610242).

With this endpoint, we now have the required functionality for an RC system to no longer fly blind.

It introduces a new flag `--rest-api` denoting the port number the API should listen to. If this is omitted, it uses port 0 and lets the OS choose an available port. The actually used port is available via `dunedaq::rest::Api::get_port()`

The API also serves `/api/v0/modules` and `/api/v0/commands/history`. These endpoints describe the active modules and their available commands, and the history of executed commands and their payload.

As a convenience, the `/` endpoint prints a list of available endpoints
```bash
$ curl localhost:8080/              
{
  "routes": [
    "GET /",
    "GET /api/v0/commands/history",
    "GET /api/v0/healthz",
    "GET /api/v0/modules"
  ]
}
```
