### PR TITLE
Add moo templates to make opmon info structs with std::atomic member variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,3 +51,4 @@ daq_add_unit_test(NamedObject_test        )
 ##############################################################################
 
 daq_install()
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/schema/  DESTINATION ${CMAKE_INSTALL_SCHEMADIR} OPTIONAL FILES_MATCHING PATTERN "*.j2")

--- a/schema/appfwk/OpmonNljs.hpp.j2
+++ b/schema/appfwk/OpmonNljs.hpp.j2
@@ -1,0 +1,84 @@
+{% import 'ocpp.hpp.j2' as cppm %}
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for shema in 
+ * {{cppm.ns(model)}} to be serialized via nlohmann::json.
+ */
+{% set tcname = "Nljs" %}
+#ifndef {{cppm.headerguard(model, tcname)}}
+#define {{cppm.headerguard(model, tcname)}}
+
+// My structs
+{% set ctxpath = model.ctxpath or [] %}
+{% set prefix = model.path|relpath(ctxpath)|join("/") %}
+{% if prefix %}
+#include "{{ prefix }}/OpmonStructs.hpp"
+{% else %}
+#include "OpmonStructs.hpp"
+{% endif %}
+
+{% if model.extrefs %}
+// {{tcname}} for externally referenced schema
+{% endif %}
+{% for ep in model.extrefs %}
+{% if ep %}
+#include "{{ep|listify|join("/")}}/{{tcname}}.hpp"
+{% else %}
+#include "{{tcname}}.hpp"
+{% endif %}
+{% endfor %}
+
+#include <nlohmann/json.hpp>
+
+{{ cppm.ns(model) }} {
+
+    using data_t = nlohmann::json;
+
+    {%- for fqn in model.byscn.enum -%}
+    {%- set e = model.byref[fqn] -%}
+    {% set n = fqn|listify|relpath(model.path)|join("::") %}
+    NLOHMANN_JSON_SERIALIZE_ENUM( {{n}}, {
+            {% for sname in e.symbols %}
+            { {{"::".join(model.path)}}::{{n}}::{{sname}}, "{{sname}}" },
+            {% endfor %}
+        })
+    {% endfor %}
+
+    {% for fqn in model.byscn.record %}    
+    {% set r = model.byref[fqn] %}
+    {% set n = fqn|listify|relpath(model.path)|join("::") %}
+    inline void to_json(data_t& j, const {{n}}& obj) {
+        {% for b in r.fields if b.name.startswith("_base_") %}
+        to_json(j, (const {{b.type}}&)obj);
+        {% endfor %}
+        {% for f in r.fields if not f.name.startswith("_base_") %}
+        {% if f.item in model.byscn.number %}
+          j["{{f.name}}"] = obj.{{f.name}}.load();
+        {% else %}
+          j["{{f.name}}"] = obj.{{f.name}};
+        {% endif %}
+        {% endfor%}
+    }
+    
+    inline void from_json(const data_t& j, {{r.name}}& obj) {
+        {% for b in r.fields if b.name.startswith("_base_") %}
+        from_json(j, ({{b.type}}&)obj);
+        {% endfor %}
+        {% for f in r.fields if not f.name.startswith("_base_") %}
+        {% if f.item in model.byscn.any %}
+        obj.{{f.name}} = j.at("{{f.name}}");
+        {% elif f.item in model.byscn.number %}
+        if (j.contains("{{f.name}}"))
+          obj.{{f.name}}.store(j.at("{{f.name}}").get<{{model.lang.dtypes[model.byref[f.item].dtype]}}>());
+        {% else %}
+        if (j.contains("{{f.name}}"))
+          j.at("{{f.name}}").get_to(obj.{{f.name}});
+        {% endif %}
+        {% endfor%}
+    }
+    {% endfor %}
+    
+} // {{ cppm.ns(model) }}
+
+#endif // {{cppm.headerguard(model, tcname)}}

--- a/schema/appfwk/OpmonStructs.hpp.j2
+++ b/schema/appfwk/OpmonStructs.hpp.j2
@@ -1,0 +1,42 @@
+{% import 'ocpp.hpp.j2' as cppm %}
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains struct and other type definitions for schema in 
+ * {{cppm.ns(model)}}.
+ */
+{% set tcname = "OpmonStructs" %}
+#ifndef {{cppm.headerguard(model, tcname)}}
+#define {{cppm.headerguard(model, tcname)}}
+
+#include <cstdint>
+{% for ep in model.extrefs %}
+#include "{{ep|listify|relpath(model.extpath)|join("/")}}/{{tcname}}.hpp"
+{% endfor %}
+
+{% for schema, typeref in model.byscn.items() %}
+{% if typeref %}{% for imp in model.lang.imports.get(schema, []) %}
+#include <{{imp}}>
+{% endfor %}{% endif %}
+{% endfor %}
+
+#include <atomic>
+
+{{ cppm.ns(model) }} {
+
+    {% for t in model.types %}
+    // @brief {{ t.doc }}
+    {% if t.schema == "number" %}
+      {% if t.dtype[0] == "u" %}
+      using {{t.name}} = std::atomic<{{model.lang.dtypes[t.dtype]}}>; // NOLINT
+      {% else %}
+      using {{t.name}} = std::atomic<{{model.lang.dtypes[t.dtype]}}>;
+      {% endif %}
+    {% else %}
+    {{ cppm["declare_"+t.schema](model, t)|indent }}
+    {% endif%}
+
+    {% endfor %}
+} // {{ cppm.ns(model) }}
+
+#endif // {{cppm.headerguard(model, tcname)}}


### PR DESCRIPTION
Our normal codegen-ed structs (via `ostructs.hpp.j2`) have numeric member variables that are bare instances of the numeric type
they represent. Eg:

```cpp
struct mymodule::Info {
   uint32_t a_counter;
   uint32_t another_counter;
};
```

We pass these structs to the operational monitoring via the `get_info()` function, which is typically called from a different thread than the one in which the counters are actually filled. That means we have to "shadow" each of the members of `mymodule::Info` with a `std::atomic` which is a member of `MyModule`, and then copy the value of each atomic into the `Info` object inside `get_info()`. (In this example, we have to add `std::atomic<uint32_t> m_a_counter, m_another_counter;` members to `MyModule`)

We can avoid this duplication by holding a `mymodule::Info` as a member variable of `MyModule` and updating the counters in that object. This in turn means that the counters in the `Info` object have to be atomic, ie:

```cpp
struct mymodule::Info {
   std::atomic<uint32_t> a_counter;
   std::atomic<uint32_t> another_counter;
};
```

This PR introduces a new pair of moo templates, `OpmonStructs.hpp.j2` and `OpmonNljs.hpp.j2`, which correspond to moo's existing `ostructs.hpp.j2` and `onljs2.hpp.j2`. The only real change is making all member variables that have moo-type "number" into `std::atomic`. (We also have to do a bit of work to make the `to_json()` and `from_json()` functions play nice with the atomic
variables.)

(`*.j2` files in the `schema/` directory aren't currently installed by `daq_install()`, so we install them "manually" in `CMakeLists.txt`. See https://github.com/DUNE-DAQ/daq-cmake/issues/44 )

To take advantage of the new-style info structs, no changes are needed to "info" schema files. But in `CMakeLists.txt`, call `daq_codegen()` for your "info" schema with the "opmon" templates, eg:

```cmake
daq_codegen(mymoduleinfo.jsonnet
            myothermoduleinfo.jsonnet
            DEP_PKGS appfwk TEMPLATES appfwk/OpmonStructs.hpp.j2 appfwk/OpmonNljs.hpp.j2 )
```

In `MyModule`, add a member variable of type `mymodule::Info` (`m_info`, say) and fill/increment its members in any thread you like. `get_info()` can then be implemented simply as:

```cpp
void
MyModule::get_info(opmonlib::InfoCollector& ci, int /*level*/)
{
  ci.add(m_info);
}
```

Notes: this doesn't change anything about the opmon interface. It's also completely optional, in that info structs can be left in the "old" format, with duplication, if desired.