### PR TITLE
Change the top-level section name for less confusion on the

### DIFF
--- a/docs/Daq-Application.md
+++ b/docs/Daq-Application.md
@@ -1,4 +1,4 @@
-# Introduction
+# DAQ Application
 
 `daq_application` is the main entry point for all _dunedaq_ processes that contain DAQModules and Queues. At program start, every `daq_application` instance only knows the basic information necessary for it to connect to Run Control and receive more information via the `init` and `conf` commands.
 

--- a/docs/ThreadHelper-Usage-Notes.md
+++ b/docs/ThreadHelper-Usage-Notes.md
@@ -1,4 +1,4 @@
-# Introduction
+# About appfwk::ThreadHelper
 
 ThreadHelper defines a std::thread which runs the do_work() function as well as methods to start and stop that thread.
 It is intended to help reduce code duplication for the common task of starting and stopping threads.


### PR DESCRIPTION
documentation website.