### PR TITLE
Eflumerf/remove queue config

### DIFF
--- a/include/appfwk/QueueRegistry.hpp
+++ b/include/appfwk/QueueRegistry.hpp
@@ -13,6 +13,7 @@
 
 #include "appfwk/Queue.hpp"
 
+#include "appfwk/app/Nljs.hpp"
 #include "ers/Issue.hpp"
 #include "opmonlib/InfoCollector.hpp"
 
@@ -22,35 +23,6 @@
 
 namespace dunedaq {
 namespace appfwk {
-
-/**
- * @brief The QueueConfig class encapsulates the basic configuration common to
- * all Queue types
- */
-struct QueueConfig
-{
-  /**
-   * @brief Enumeration of all possible types of Queue
-   */
-  enum queue_kind
-  {
-    kUnknown = -1,
-    kStdDeQueue = 1, ///< The StdDeQueue
-    kFollySPSCQueue = 2,
-    kFollyMPMCQueue = 3,
-  };
-
-  /**
-   * @brief  Transform a string to a queue_kind
-   * @param name Name of the Queue Type
-   * @return Queue type corresponding to the name. Currently only std_deque.
-   */
-  static queue_kind stoqk(const std::string& name);
-
-  QueueConfig::queue_kind kind = queue_kind::kUnknown; ///< The kind of Queue represented by this
-                                                       ///< QueueConfig
-  size_t capacity = 0;                                 ///< The maximum size of the queue
-};
 
 /**
  * @brief The QueueRegistry class manages all Queue instances and gives out
@@ -81,15 +53,17 @@ public:
 
   /**
    * @brief Configure the QueueRegistry
-   * @param configmap Map relating Queue names to their configurations
+   * @param qspecs Queue Specifications
    */
-  void configure(const std::map<std::string, QueueConfig>& config_map);
+  void configure(const app::QueueSpecs& qspecs);
 
   // Gather statistics from queues
   void gather_stats(opmonlib::InfoCollector& ic, int level);
 
   // ONLY TO BE USED FOR TESTING!
   static void reset() { s_instance.reset(nullptr); }
+
+  bool has_queue(std::string const& name) const { return m_queue_registry.count(name); }
 
 private:
   struct QueueEntry
@@ -101,10 +75,10 @@ private:
   QueueRegistry() = default;
 
   template<typename T>
-  std::shared_ptr<QueueBase> create_queue(const std::string& name, const QueueConfig& config);
+  std::shared_ptr<QueueBase> create_queue(const std::string& name, const app::QueueSpec& config);
 
   std::map<std::string, QueueEntry> m_queue_registry;
-  std::map<std::string, QueueConfig> m_queue_config_map;
+  std::map<std::string, app::QueueSpec> m_queue_config_map;
 
   bool m_configured{ false };
 

--- a/include/appfwk/detail/QueueRegistry.hxx
+++ b/include/appfwk/detail/QueueRegistry.hxx
@@ -43,23 +43,23 @@ QueueRegistry::get_queue(const std::string& name)
 
 template<typename T>
 std::shared_ptr<QueueBase>
-QueueRegistry::create_queue(const std::string& name, const QueueConfig& config)
+QueueRegistry::create_queue(const std::string& name, const app::QueueSpec& config)
 {
 
   std::shared_ptr<QueueBase> queue;
   switch (config.kind) {
-    case QueueConfig::kStdDeQueue:
+    case app::QueueKind::StdDeQueue:
       queue = std::make_shared<StdDeQueue<T>>(name, config.capacity);
       break;
-    case QueueConfig::kFollySPSCQueue:
+    case app::QueueKind::FollySPSCQueue:
       queue = std::make_shared<FollySPSCQueue<T>>(name, config.capacity);
       break;
-    case QueueConfig::kFollyMPMCQueue:
+    case app::QueueKind::FollyMPMCQueue:
       queue = std::make_shared<FollyMPMCQueue<T>>(name, config.capacity);
       break;
 
     default:
-      throw QueueKindUnknown(ERS_HERE, std::to_string(config.kind));
+      throw QueueKindUnknown(ERS_HERE, app::str(config.kind));
   }
 
   return queue;

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -57,35 +57,7 @@ DAQModuleManager::init_modules(const app::ModSpecs& mspecs)
 void
 DAQModuleManager::init_queues(const app::QueueSpecs& qspecs)
 {
-  std::map<std::string, QueueConfig> queue_cfgs;
-  for (const auto& qs : qspecs) {
-
-    // N.B.: here we mimic the behavior of daq_application and
-    // ignore the kind.  This requires user configuration to
-    // assure unique queue names across all queue types.
-    const std::string queue_name = qs.inst;
-    // fixme: maybe one day replace QueueConfig with codgen.
-    // Until then, wheeee....
-    QueueConfig qc;
-    switch (qs.kind) {
-      case app::QueueKind::StdDeQueue:
-        qc.kind = QueueConfig::queue_kind::kStdDeQueue;
-        break;
-      case app::QueueKind::FollySPSCQueue:
-        qc.kind = QueueConfig::queue_kind::kFollySPSCQueue;
-        break;
-      case app::QueueKind::FollyMPMCQueue:
-        qc.kind = QueueConfig::queue_kind::kFollyMPMCQueue;
-        break;
-      default:
-        throw MissingComponent(ERS_HERE, "unknown queue type");
-        break;
-    }
-    qc.capacity = qs.capacity;
-    queue_cfgs[queue_name] = qc;
-    TLOG_DEBUG(2) << "Adding queue: " << queue_name;
-  }
-  QueueRegistry::get().configure(queue_cfgs);
+  QueueRegistry::get().configure(qspecs);
 }
 
 void

--- a/src/QueueRegistry.cpp
+++ b/src/QueueRegistry.cpp
@@ -28,13 +28,15 @@ QueueRegistry::get()
 }
 
 void
-QueueRegistry::configure(const std::map<std::string, QueueConfig>& config_map)
+QueueRegistry::configure(const app::QueueSpecs& qspecs)
 {
   if (m_configured) {
     throw QueueRegistryConfigured(ERS_HERE);
   }
 
-  m_queue_config_map = config_map;
+  for (auto& qspec : qspecs) {
+    m_queue_config_map[qspec.inst] = qspec;
+  }
   m_configured = true;
 }
 
@@ -49,19 +51,6 @@ QueueRegistry::gather_stats(opmonlib::InfoCollector& ic, int level)
       ic.add(name, tmp_ci);
     }
   }
-}
-
-QueueConfig::queue_kind
-QueueConfig::stoqk(const std::string& name)
-{
-  if (name == "StdDeQueue" || name == "std_deque")
-    return queue_kind::kStdDeQueue;
-  else if (name == "FollySPSCQueue")
-    return queue_kind::kFollySPSCQueue;
-  else if (name == "FollyMPMCQueue")
-    return queue_kind::kFollyMPMCQueue;
-  else
-    throw QueueKindUnknown(ERS_HERE, name);
 }
 
 } // namespace dunedaq::appfwk

--- a/test/apps/dummy_module_test.cxx
+++ b/test/apps/dummy_module_test.cxx
@@ -25,8 +25,8 @@ main()
   TLOG() << "Creating Module instances...";
   std::shared_ptr<DAQModule> dummy_module = make_module("DummyModule", "dummy");
 
-  std::map<std::string, QueueConfig> queue_map;
-  QueueRegistry::get().configure(queue_map);
+  app::QueueSpecs qspecs;
+  QueueRegistry::get().configure(qspecs);
 
   // Init
   TLOG() << "Calling init on modules...";

--- a/unittest/DAQSink_DAQSource_test.cxx
+++ b/unittest/DAQSink_DAQSource_test.cxx
@@ -34,9 +34,14 @@ struct DAQSinkDAQSourceTestFixture
 
   void setup()
   {
-    std::map<std::string, QueueConfig> queue_map = { { "dummy", { QueueConfig::queue_kind::kStdDeQueue, 100 } } };
+    app::QueueSpecs test_config;
+    app::QueueSpec qc;
+    qc.kind = app::QueueKind::StdDeQueue;
+    qc.capacity = 100;
+    qc.inst = "dummy";
+    test_config.push_back(qc);
 
-    QueueRegistry::get().configure(queue_map);
+    QueueRegistry::get().configure(test_config);
   }
 };
 

--- a/unittest/QueueRegistry_test.cxx
+++ b/unittest/QueueRegistry_test.cxx
@@ -22,33 +22,38 @@ using namespace dunedaq::appfwk;
 
 BOOST_AUTO_TEST_CASE(Configure)
 {
-  std::map<std::string, QueueConfig> test_map;
-  QueueConfig qc;
-  qc.kind = QueueConfig::kUnknown;
+  app::QueueSpecs test_config;
+  app::QueueSpec qc;
+  qc.kind = app::QueueKind::Unknown;
   qc.capacity = 10;
-  test_map["test_queue_unknown"] = qc;
-  qc.kind = QueueConfig::kStdDeQueue;
+  qc.inst = "test_queue_unknown";
+  test_config.push_back(qc);
+  qc.kind = app::QueueKind::StdDeQueue;
   qc.capacity = 10;
-  test_map["test_queue_stddeque"] = qc;
-  qc.kind = QueueConfig::kFollySPSCQueue;
+  qc.inst = "test_queue_stddeque";
+  test_config.push_back(qc);
+  qc.kind = app::QueueKind::FollySPSCQueue;
   qc.capacity = 10;
-  test_map["test_queue_fspsc"] = qc;
-  qc.kind = QueueConfig::kFollyMPMCQueue;
+  qc.inst = "test_queue_fspsc";
+  test_config.push_back(qc);
+  qc.kind = app::QueueKind::FollyMPMCQueue;
   qc.capacity = 10;
-  test_map["test_queue_fmpmc"] = qc;
+  qc.inst = "test_queue_fmpmc";
+  test_config.push_back(qc);
 
-  QueueRegistry::get().configure(test_map);
+  QueueRegistry::get().configure(test_config);
 
-  BOOST_REQUIRE_EXCEPTION(
-    QueueRegistry::get().configure(test_map), QueueRegistryConfigured, [&](QueueRegistryConfigured) { return true; });
+  BOOST_REQUIRE_EXCEPTION(QueueRegistry::get().configure(test_config),
+                          QueueRegistryConfigured,
+                          [&](QueueRegistryConfigured) { return true; });
 }
 
 BOOST_AUTO_TEST_CASE(StoQK)
 {
-  BOOST_REQUIRE_EQUAL(QueueConfig::stoqk("StdDeQueue"), QueueConfig::kStdDeQueue);
-  BOOST_REQUIRE_EQUAL(QueueConfig::stoqk("FollySPSCQueue"), QueueConfig::kFollySPSCQueue);
-  BOOST_REQUIRE_EQUAL(QueueConfig::stoqk("FollyMPMCQueue"), QueueConfig::kFollyMPMCQueue);
-  BOOST_REQUIRE_EXCEPTION(QueueConfig::stoqk("blahblahblah"), QueueKindUnknown, [&](QueueKindUnknown) { return true; });
+  BOOST_REQUIRE(app::parse_QueueKind("StdDeQueue") == app::QueueKind::StdDeQueue);
+  BOOST_REQUIRE(app::parse_QueueKind("FollySPSCQueue") == app::QueueKind::FollySPSCQueue);
+  BOOST_REQUIRE(app::parse_QueueKind("FollyMPMCQueue") == app::QueueKind::FollyMPMCQueue);
+  BOOST_REQUIRE(app::parse_QueueKind("blahblahblah") == app::QueueKind::Unknown);
 }
 
 BOOST_AUTO_TEST_CASE(GatherStats)


### PR DESCRIPTION
Remove the QueueConfig helper struct, instead using confgen structs directly. Resolves a fixme comment.

Corresponding compatibility branches have been made in timinglibs, dfmodules, and trigger, but there may be other compatibility changes needed elsewhere.