### PR TITLE
Use topological sort on the start/stop order between apps

### DIFF
--- a/python/appfwk/conf_utils.py
+++ b/python/appfwk/conf_utils.py
@@ -532,8 +532,7 @@ def make_system_command_datas(the_system, verbose=False):
 
     if the_system.app_start_order is None:
         app_deps = make_app_deps(the_system, verbose)
-        # the_system.app_start_order = list(nx.algorithms.dag.topological_sort(app_deps))
-        the_system.app_start_order = list(app_deps.nodes)
+        the_system.app_start_order = list(nx.algorithms.dag.topological_sort(app_deps))[::-1]
 
     system_command_datas=dict()
 


### PR DESCRIPTION
This PR modifies `conf_utils.py` to use the topological sort to set the between-applications start and stop order. It looks like it was mistakenly removed by commit [16994024df21dd02eb6b877ca8de1682672fd54e](https://github.com/DUNE-DAQ/appfwk/commit/16994024df21dd02eb6b877ca8de1682672fd54e)