### PR TITLE
Reverse start/stop order to fix hang at stop time

### DIFF
--- a/python/appfwk/conf_utils.py
+++ b/python/appfwk/conf_utils.py
@@ -532,7 +532,7 @@ def make_system_command_datas(the_system, verbose=False):
 
     if the_system.app_start_order is None:
         app_deps = make_app_deps(the_system, verbose)
-        the_system.app_start_order = list(nx.algorithms.dag.topological_sort(app_deps))[::-1]
+        the_system.app_start_order = list(nx.algorithms.dag.topological_sort(app_deps))
 
     system_command_datas=dict()
 


### PR DESCRIPTION
Evidently #222 got the start/stop order the wrong way round, causing hangs at stop. This PR reverses the start/stop order, and appears to fix #227.