### PR TITLE
NetworkManager moving to iomanager

### DIFF
--- a/src/detail/DAQModuleManager.hxx
+++ b/src/detail/DAQModuleManager.hxx
@@ -228,7 +228,7 @@ DAQModuleManager::gather_stats(opmonlib::InfoCollector& ci, int level)
 {
 
   iomanager::QueueRegistry::get().gather_stats(ci, level);
-  networkmanager::NetworkManager::get().gather_stats(ci, level);
+  iomanager::NetworkManager::get().gather_stats(ci, level);
 
   for (const auto& [mod_name, mod_ptr] : m_module_map) {
     opmonlib::InfoCollector tmp_ci;


### PR DESCRIPTION
Requires https://github.com/DUNE-DAQ/iomanager/pull/21 to be merged first