### PR TITLE
Added virtual destructor to quiet compiler warning

### DIFF
--- a/include/appfwk/ConfFacility.hpp
+++ b/include/appfwk/ConfFacility.hpp
@@ -42,7 +42,7 @@ class ConfFacility
 {
 public:
   explicit ConfFacility(std::string /*uri*/) {}
-  ~ConfFacility() {}
+  virtual ~ConfFacility() {}
   ConfFacility(const ConfFacility&) = 
     delete; ///< ConfFacility is not copy-constructible
   ConfFacility& operator=(const ConfFacility&) =

--- a/include/appfwk/Interruptible.hpp
+++ b/include/appfwk/Interruptible.hpp
@@ -28,6 +28,11 @@ public:
   {}
 
   /**
+   * @brief Interruptible destructor
+   */
+  virtual ~Interruptible() noexcept = default;
+
+  /**
    * @brief Send a notification that an interrupt is requested.
    *
    * This function is virtual to allow classes which inherit from Interruptible to implement


### PR DESCRIPTION
I'm not sure if the compiler warnings that we see with the current code are red herrings, but the changes in this PR quiet them.