### PR TITLE
Add application parameter for connectivity service publish interval, and

### DIFF
--- a/schema/appfwk/app.jsonnet
+++ b/schema/appfwk/app.jsonnet
@@ -25,6 +25,7 @@ local cs = {
     label: s.string("Label", moo.re.ident_only,
                    doc="A label hard-wired into code"),
     switch: s.boolean("Switch", doc="A boolean switch"),
+    count: s.number("Count", "i8", doc="A count of things"),
     
     mspec: s.record("ModSpec", [
         s.field("plugin", self.plugin,
@@ -57,6 +58,8 @@ local cs = {
                 doc="Initial network connection specifications"),
         s.field("use_connectivity_service", self.switch, default=true, 
                 doc="Whether to use the ConnectivityService to register/request connections"),
+        s.field("connectivity_service_interval_ms", self.count, default=1000,
+                doc="Interval with which the connectivity service client will republish connections as a keep-alive and check for new publishers for its subscribers")
     ], doc="The app-level init command data object struction"),
 
 };

--- a/src/detail/DAQModuleManager.hxx
+++ b/src/detail/DAQModuleManager.hxx
@@ -34,7 +34,7 @@ void
 DAQModuleManager::initialize(const dataobj_t& data)
 {
   auto ini = data.get<app::Init>();
-  get_iomanager()->configure(ini.queues, ini.connections, ini.use_connectivity_service);
+  get_iomanager()->configure(ini.queues, ini.connections, ini.use_connectivity_service, std::chrono::milliseconds(ini.connectivity_service_interval_ms));
   init_modules(ini.modules);
   this->m_initialized = true;
 }

--- a/test/scripts/confdata/TestApp_init.json
+++ b/test/scripts/confdata/TestApp_init.json
@@ -1,15 +1,16 @@
 {
-      "modules": [
+  "modules": [
 
-        {
-          "data": {
-            "conn_refs": [            ]
-          },
-          "inst": "dummy_module_0",
-          "plugin": "DummyModule"
-        }
-      ],
-      "connections": [
+    {
+      "data": {
+        "conn_refs": []
+      },
+      "inst": "dummy_module_0",
+      "plugin": "DummyModule"
+    }
+  ],
+  "connections": [
 
-      ]
+  ],
+  "use_connectivity_service": false
 }

--- a/unittest/Application_test.cxx
+++ b/unittest/Application_test.cxx
@@ -35,13 +35,13 @@ BOOST_TEST_GLOBAL_FIXTURE(EnvFixture);
 
 BOOST_AUTO_TEST_CASE(Constructor)
 {
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
 }
 
 BOOST_AUTO_TEST_CASE(Init)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
   app.init();
 
   dunedaq::iomanager::IOManager::get()->reset();
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(Run)
   std::atomic<bool> end_marker = false;
 
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
 
   BOOST_REQUIRE_EXCEPTION(
     app.run(end_marker), ApplicationNotInitialized, [&](ApplicationNotInitialized) { return true; });
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(Run)
 BOOST_AUTO_TEST_CASE(Start)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
   app.init();
 
   dunedaq::appfwk::cmd::CmdObj start;
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(Start)
 BOOST_AUTO_TEST_CASE(Stop)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
   app.init();
 
   dunedaq::rcif::cmd::StartParams start_params;
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(Stop)
 BOOST_AUTO_TEST_CASE(NotInitialized)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
   dunedaq::rcif::cmd::RCCommand cmd;
   nlohmann::json cmd_data;
 
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(InvalidCommandTest)
 {
 
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
   app.init();
 
   dunedaq::rcif::cmd::RCCommand cmd;
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(InvalidCommandTest)
 BOOST_AUTO_TEST_CASE(CommandThrowsException)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
   app.init();
 
   dunedaq::rcif::cmd::RCCommand cmd;
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(CommandThrowsException)
 BOOST_AUTO_TEST_CASE(Stats)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
 
   dunedaq::opmonlib::InfoCollector ic;
   app.gather_stats(ic, 0);
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(Stats)
 BOOST_AUTO_TEST_CASE(State)
 {
   dunedaq::get_iomanager()->reset();
-  Application app("app_name", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
+  Application app("TestApp", "partition_name", "stdin://" + TEST_JSON_FILE, "stdout://flat", "file://"+TEST_JSON_DIR);
 
   std::string state_in = "state";
   app.set_state(state_in);


### PR DESCRIPTION
pass it to IOManager. Fix instances in Application_test which were using incorrect app name for given configuration scripts (tension between Application_test and daq_application.sh resolved). Update init to turn off connectivity service for Application test.

Follows https://github.com/DUNE-DAQ/iomanager/pull/35