### PR TITLE
Remove SIGHUP from signal handler list.

### DIFF
--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -56,7 +56,7 @@ main(int argc, char* argv[])
 
   // Setup signals
   // std::signal(SIGABRT, signal_handler);
-  std::signal(SIGTERM, signal_handler);
+  // std::signal(SIGTERM, signal_handler);
   std::signal(SIGINT, signal_handler);
   std::signal(SIGQUIT, signal_handler);
   //std::signal(SIGHUP, signal_handler);

--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -59,7 +59,7 @@ main(int argc, char* argv[])
   std::signal(SIGTERM, signal_handler);
   std::signal(SIGINT, signal_handler);
   std::signal(SIGQUIT, signal_handler);
-  std::signal(SIGHUP, signal_handler);
+  //std::signal(SIGHUP, signal_handler);
 
   using namespace dunedaq;
 


### PR DESCRIPTION
Commenting out this signal handler appears to resolve many issues with `daq_application` instances hanging around after NanoRC thinks that they should be gone. While not exactly a "solution" for the problem, I think it's a robust enough workaround to merit inclusion for now, as the "real" solution will likely involve lots of work on the CCM side.