### PR TITLE
JCF: given changes due to DUNE-DAQ/daq-cmake#100, make sure that file…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ daq_add_library(DAQModule*.cpp LINK_LIBRARIES ${APPFWK_DEPENDENCIES})
 
 ##############################################################################
 # Plugins
-daq_add_plugin(fileConfFacility duneConfFacility LINK_LIBRARIES ers::ers logging::logging nlohmann_json::nlohmann_json)
-daq_add_plugin(dbConfFacility duneConfFacility LINK_LIBRARIES ers::ers logging::logging nlohmann_json::nlohmann_json pistache_shared)
+daq_add_plugin(fileConfFacility duneConfFacility LINK_LIBRARIES ers::ers logging::logging nlohmann_json::nlohmann_json ${CETLIB} ${CETLIB_EXCEPT})
+daq_add_plugin(dbConfFacility duneConfFacility LINK_LIBRARIES ers::ers logging::logging nlohmann_json::nlohmann_json pistache_shared ${CETLIB} ${CETLIB_EXCEPT})
 
 # ##############################################################################
 # Applications


### PR DESCRIPTION
…ConfFacility and dbConfFacility link to cetlib so that all functions in ConfFacility.hpp have definitions

UPSHOT: there's no need to merge this until a version of daq-cmake which includes the PR DUNE-DAQ/daq-cmake#101 has been cut. 