### PR TITLE
Dont ignore the `use_connectivity_service` flag

### DIFF
--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -47,7 +47,7 @@ DAQModuleManager::initialize(std::shared_ptr<ConfigurationManager> cfgMgr, opmon
   m_module_configuration = std::make_shared<ModuleConfiguration>(cfgMgr);
   get_iomanager()->configure(m_module_configuration->queues(),
                              m_module_configuration->networkconnections(),
-                             true,
+                             cfgMgr->session()->get_use_connectivity_service(),
                              std::chrono::milliseconds(csInterval),
                              opm);
   init_modules(m_module_configuration->modules(), opm);

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -47,7 +47,7 @@ DAQModuleManager::initialize(std::shared_ptr<ConfigurationManager> cfgMgr, opmon
   m_module_configuration = std::make_shared<ModuleConfiguration>(cfgMgr);
   get_iomanager()->configure(m_module_configuration->queues(),
                              m_module_configuration->networkconnections(),
-                             cfgMgr->session()->get_use_connectivity_service(),
+                             cfgMgr->session()->get_use_connectivity_server(),
                              std::chrono::milliseconds(csInterval),
                              opm);
   init_modules(m_module_configuration->modules(), opm);


### PR DESCRIPTION
Correct a little typo (with Eric's help) that made the app always use the connectivity server, regardless of `session.use_connectivity_server`.