### PR TITLE
Revert "Remove the `--name` and `--session` from the cli, and use env instead"

### DIFF
--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -22,6 +22,9 @@
 #include <string>
 #include <vector>
 
+
+
+
 /**
  * @brief Using namespace for convenience
  */
@@ -76,29 +79,19 @@ main(int argc, char* argv[])
     exit(0);
   }
 
-  // Get the application and session name from the environment.
-  std::string app_name = "";
-  std::string session_name = "";
-
-  char* app_name_c = getenv("DUNEDAQ_APPLICATION_NAME");
-  char* session_name_c = getenv("DUNEDAQ_SESSION");
-
-  bool missing_env_var =
-    !app_name_c || std::string(app_name_c) == "" || !session_name_c || std::string(session_name_c) == "";
-  if (missing_env_var) {
-    ers::error(appfwk::EnvironmentVariableNotFound(ERS_HERE, "DUNEDAQ_APPLICATION_NAME or DUNEDAQ_SESSION"));
-    exit(1);
-  }
-
-  app_name = app_name_c;
-  session_name = session_name_c;
+  // Set/Update the application and partition name in the environment. Used by logging/ers.
+  setenv("DUNEDAQ_APPLICATION_NAME", args.app_name.c_str(), 0);
+  setenv("DUNEDAQ_PARTITION", args.session_name.c_str(), 0);
 
   // Create the Application
-  appfwk::Application app(app_name, session_name, args.command_facility_plugin_name, args.conf_service_plugin_name);
+  appfwk::Application app(args.app_name,
+                          args.session_name,
+                          args.command_facility_plugin_name,
+                          args.conf_service_plugin_name);
 
   app.init();
   app.run(run_marker);
 
-  TLOG() << "Application " << app_name << " exiting.";
+  TLOG() << "Application " << args.app_name << " exiting.";
   return 0;
 }

--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -94,8 +94,8 @@ main(int argc, char* argv[])
   session_name = session_name_c;
 
   if (args.app_name != app_name || args.session_name != session_name) {
-    ers:error(appfwk::MismatchedEnvAndCLI(ERS_HERE, "name", "DUNEDAQ_APPLICATION_NAME", args.app_name, app_name));
-    ers:error(appfwk::MismatchedEnvAndCLI(ERS_HERE, "session", "DUNEDAQ_SESSION", args.session_name, session_name));
+    ers::error(appfwk::MismatchedEnvAndCLI(ERS_HERE, "name", "DUNEDAQ_APPLICATION_NAME", args.app_name, app_name));
+    ers::error(appfwk::MismatchedEnvAndCLI(ERS_HERE, "session", "DUNEDAQ_SESSION", args.session_name, session_name));
     exit(1);
   }
 

--- a/include/appfwk/Issues.hpp
+++ b/include/appfwk/Issues.hpp
@@ -65,11 +65,6 @@ ERS_DECLARE_ISSUE(appfwk,
                   ActionPlanValidationFailed,
                   "Error validating action plan " << cmd << ", module " << module << ": " << message,
                   ((std::string)cmd)((std::string)module)((std::string)message))
-
-ERS_DECLARE_ISSUE(appfwk,
-                  EnvironmentVariableNotFound,
-                  "Environment variable " << var << " wasn't found.",
-                  ((std::string)var))
 // Re-enable coverage collection LCOV_EXCL_STOP
 } // namespace dunedaq
 

--- a/include/appfwk/Issues.hpp
+++ b/include/appfwk/Issues.hpp
@@ -67,9 +67,15 @@ ERS_DECLARE_ISSUE(appfwk,
                   ((std::string)cmd)((std::string)module)((std::string)message))
 
 ERS_DECLARE_ISSUE(appfwk,
+                  EnvironmentVariableNotFound,
+                  "Environment variable " << var << " wasn't found.",
+                  ((std::string)var))
+
+ERS_DECLARE_ISSUE(appfwk,
                   MismatchedEnvAndCLI,
                   "The command line argument \"--" << cli_name << "\" and env variable \"" << env_name << "\" must be set to the same value, but are set as \"" << cli_value << "\" and \"" << env_value << "\", respectively",
                   ((std::string)cli_name)((std::string)env_name)((std::string)cli_value)((std::string)env_value))
+
 // Re-enable coverage collection LCOV_EXCL_STOP
 } // namespace dunedaq
 

--- a/include/appfwk/Issues.hpp
+++ b/include/appfwk/Issues.hpp
@@ -65,6 +65,11 @@ ERS_DECLARE_ISSUE(appfwk,
                   ActionPlanValidationFailed,
                   "Error validating action plan " << cmd << ", module " << module << ": " << message,
                   ((std::string)cmd)((std::string)module)((std::string)message))
+
+ERS_DECLARE_ISSUE(appfwk,
+                  MismatchedEnvAndCLI,
+                  "The command line argument \"--" << cli_name << "\" and env variable \"" << env_name << "\" must be set to the same value, but are set as \"" << cli_value << "\" and \"" << env_value << "\", respectively",
+                  ((std::string)cli_name)((std::string)env_name)((std::string)cli_value)((std::string)env_value))
 // Re-enable coverage collection LCOV_EXCL_STOP
 } // namespace dunedaq
 

--- a/src/CommandLineInterpreter.hpp
+++ b/src/CommandLineInterpreter.hpp
@@ -52,7 +52,8 @@ public:
             << " known arguments (additional arguments will be stored and "
                "passed on)";
     bpo::options_description desc(descstr.str());
-    desc.add_options()(
+    desc.add_options()("name,n", bpo::value<std::string>()->required(), "Application name")(
+      "session,s", bpo::value<std::string>()->default_value("global"), "Session name")(
       "commandFacility,c", bpo::value<std::string>()->required(), "CommandFacility URI")(
       "configurationService,d", bpo::value<std::string>()->required(), "Configuration Service URI")(
       "help,h", "produce help message");
@@ -79,14 +80,17 @@ public:
       throw CommandLineIssue(ERS_HERE, *argv, e.what());
     }
 
+    output.app_name = vm["name"].as<std::string>();
+    output.session_name = vm["session"].as<std::string>();
     output.command_facility_plugin_name = vm["commandFacility"].as<std::string>();
     output.conf_service_plugin_name = vm["configurationService"].as<std::string>();
-
     return output;
   }
 
   bool help_requested{ false }; ///< Did the user just ask for help?
 
+  std::string app_name{ "" };
+  std::string session_name{ "" };
   std::string command_facility_plugin_name{ "" }; ///< Name of the CommandFacility plugin to load
   std::string conf_service_plugin_name{ "" };     ///< Name of the ConfService plugin to load
 

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -338,12 +338,6 @@ DAQModuleManager::execute(const std::string& cmd, const dataobj_t& cmd_data)
     for (auto& step : action_plan->get_steps()) {
       execute_action_plan_step(cmd, step, cmd_data, serial_execution);
     }
-
-  }
-
-  // Shutdown IOManager at scrap
-  if (cmd == "scrap") {
-    get_iomanager()->shutdown();
   }
 }
 

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -338,6 +338,12 @@ DAQModuleManager::execute(const std::string& cmd, const dataobj_t& cmd_data)
     for (auto& step : action_plan->get_steps()) {
       execute_action_plan_step(cmd, step, cmd_data, serial_execution);
     }
+
+  }
+
+  // Shutdown IOManager at scrap
+  if (cmd == "scrap") {
+    get_iomanager()->shutdown();
   }
 }
 


### PR DESCRIPTION
Reverts DUNE-DAQ/appfwk#295 requires: https://github.com/DUNE-DAQ/confmodel/pull/47