### PR TITLE
Introduce Configurable base class for Application

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -31,7 +31,7 @@ Application::Application(std::string appname,
                          std::string cmdlibimpl,
                          std::string confimpl)
   : Configurable(confimpl, appname, session) 
-  , OpMonManager(session, appname, m_config_mgr->session()->get_opmon_uri()->get_URI(appname))
+  , OpMonManager(session, appname, get_config_manager()->session()->get_opmon_uri()->get_URI(appname))
   , NamedObject(appname)
   , m_state("NONE")
   , m_busy(false)
@@ -43,12 +43,10 @@ Application::Application(std::string appname,
   m_runinfo.set_run_time(0);
 
   m_cmd_fac = cmdlib::make_command_facility(
-    cmdlibimpl,
-    session,
-    m_config_mgr->session()->get_connectivity_service()
+    cmdlibimpl, session, get_config_manager()->session()->get_connectivity_service()
   );
 
-  set_opmon_conf(m_config_mgr->application()->get_opmon_conf());
+  set_opmon_conf(get_config_manager()->application()->get_opmon_conf());
 
   TLOG() << "confimpl=<" << confimpl << ">\n";
 }
@@ -57,7 +55,7 @@ void
 Application::init()
 {
   m_cmd_fac->set_commanded(*this, get_name());
-  m_mod_mgr.initialize(m_config_mgr, *this);
+  m_mod_mgr.initialize(get_config_manager(), *this);
   set_state("INITIAL");
   m_initialized = true;
 }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -30,7 +30,7 @@ Application::Application(std::string appname,
                          std::string session,
                          std::string cmdlibimpl,
                          std::string confimpl)
-  : Configurable(confimpl, appname, session) 
+  : ConfigurationManagerOwner(confimpl, appname, session) 
   , OpMonManager(session, appname, get_config_manager()->session()->get_opmon_uri()->get_URI(appname))
   , NamedObject(appname)
   , m_state("NONE")

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -30,13 +30,13 @@ Application::Application(std::string appname,
                          std::string session,
                          std::string cmdlibimpl,
                          std::string confimpl)
-  : OpMonManager(session, appname, std::make_unique<ConfigurationManager>(confimpl, appname, session)->session()->get_opmon_uri()->get_URI(appname))
+  : Configurable(confimpl, appname, session) 
+  , OpMonManager(session, appname, m_config_mgr->session()->get_opmon_uri()->get_URI(appname))
   , NamedObject(appname)
   , m_state("NONE")
   , m_busy(false)
   , m_error(false)
   , m_initialized(false)
-  , m_config_mgr(std::make_shared<ConfigurationManager>(confimpl, appname, session))
 {
   m_runinfo.set_running(false);
   m_runinfo.set_run_number(0);

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -16,6 +16,7 @@
 #include "cmdlib/CommandFacility.hpp"
 #include "cmdlib/CommandedObject.hpp"
 
+#include "Configurable.hpp"
 #include "DAQModuleManager.hpp"
 #include "appfwk/ConfFacility.hpp"
 
@@ -54,24 +55,8 @@ ERS_DECLARE_ISSUE(appfwk,         ///< Namespace
 )
 
 // Re-enable coverage collection LCOV_EXCL_STOP
+
 namespace appfwk {
-
-    class Configurable
-    {
-    public:
-      Configurable(std::string confimpl, std::string app_name, std::string session_name)
-        : m_config_mgr(std::make_shared<ConfigurationManager>(confimpl, app_name, session_name))
-      {
-      }
-
-      Configurable(std::shared_ptr<ConfigurationManager> mgr)
-        : m_config_mgr(mgr)
-      {
-      }
-
-    protected:
-      std::shared_ptr<ConfigurationManager> m_config_mgr;
-    };
 
 class Application
   : public Configurable

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -16,7 +16,7 @@
 #include "cmdlib/CommandFacility.hpp"
 #include "cmdlib/CommandedObject.hpp"
 
-#include "Configurable.hpp"
+#include "ConfigurationManagerOwner.hpp"
 #include "DAQModuleManager.hpp"
 #include "appfwk/ConfFacility.hpp"
 
@@ -59,7 +59,7 @@ ERS_DECLARE_ISSUE(appfwk,         ///< Namespace
 namespace appfwk {
 
 class Application
-  : public Configurable
+  : public ConfigurationManagerOwner
   , public cmdlib::CommandedObject
   , public opmonlib::OpMonManager
   , public utilities::NamedObject

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -56,8 +56,26 @@ ERS_DECLARE_ISSUE(appfwk,         ///< Namespace
 // Re-enable coverage collection LCOV_EXCL_STOP
 namespace appfwk {
 
+    class Configurable
+    {
+    public:
+      Configurable(std::string confimpl, std::string app_name, std::string session_name)
+        : m_config_mgr(std::make_shared<ConfigurationManager>(confimpl, app_name, session_name))
+      {
+      }
+
+      Configurable(std::shared_ptr<ConfigurationManager> mgr)
+        : m_config_mgr(mgr)
+      {
+      }
+
+    protected:
+      std::shared_ptr<ConfigurationManager> m_config_mgr;
+    };
+
 class Application
-  : public cmdlib::CommandedObject
+  : public Configurable
+  , public cmdlib::CommandedObject
   , public opmonlib::OpMonManager
   , public utilities::NamedObject
 {
@@ -106,7 +124,6 @@ private:
   dunedaq::rcif::opmon::RunInfo m_runinfo;
   DAQModuleManager m_mod_mgr;
   std::shared_ptr<cmdlib::CommandFacility> m_cmd_fac;
-  std::shared_ptr<ConfigurationManager> m_config_mgr;
 };
 
 } // namespace appfwk

--- a/src/Configurable.hpp
+++ b/src/Configurable.hpp
@@ -1,0 +1,37 @@
+/**
+ * @file Configurable.hpp Instantiates and owns a ConfigurationManager
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef APPFWK_INCLUDE_APPFWK_CONFIGURABLE_HPP_
+#define APPFWK_INCLUDE_APPFWK_CONFIGURABLE_HPP_
+
+#include "appfwk/ConfigurationManager.hpp"
+
+#include <memory>
+#include <string>
+
+namespace dunedaq {
+namespace appfwk {
+
+class Configurable
+{
+public:
+  Configurable(std::string confimpl, std::string app_name, std::string session_name)
+    : m_config_mgr(std::make_shared<ConfigurationManager>(confimpl, app_name, session_name))
+  {
+  }
+
+  std::shared_ptr<ConfigurationManager> get_config_manager() const { return m_config_mgr; }
+
+private:
+  std::shared_ptr<ConfigurationManager> m_config_mgr;
+};
+
+} // namespace appfwk
+} // namespace dunedaq
+
+#endif // APPFWK_INCLUDE_APPFWK_CONFIGURABLE_HPP_

--- a/src/ConfigurationManagerOwner.hpp
+++ b/src/ConfigurationManagerOwner.hpp
@@ -1,13 +1,13 @@
 /**
- * @file Configurable.hpp Instantiates and owns a ConfigurationManager
+ * @file ConfigurationManagerOwner.hpp Instantiates and owns a ConfigurationManager
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
 
-#ifndef APPFWK_INCLUDE_APPFWK_CONFIGURABLE_HPP_
-#define APPFWK_INCLUDE_APPFWK_CONFIGURABLE_HPP_
+#ifndef APPFWK_INCLUDE_APPFWK_CONFIGURATIONMANAGEROWNER_HPP_
+#define APPFWK_INCLUDE_APPFWK_CONFIGURATIONMANAGEROWNER_HPP_
 
 #include "appfwk/ConfigurationManager.hpp"
 
@@ -17,10 +17,10 @@
 namespace dunedaq {
 namespace appfwk {
 
-class Configurable
+class ConfigurationManagerOwner
 {
 public:
-  Configurable(std::string confimpl, std::string app_name, std::string session_name)
+  ConfigurationManagerOwner(std::string confimpl, std::string app_name, std::string session_name)
     : m_config_mgr(std::make_shared<ConfigurationManager>(confimpl, app_name, session_name))
   {
   }
@@ -34,4 +34,4 @@ private:
 } // namespace appfwk
 } // namespace dunedaq
 
-#endif // APPFWK_INCLUDE_APPFWK_CONFIGURABLE_HPP_
+#endif // APPFWK_INCLUDE_APPFWK_CONFIGURATIONMANAGEROWNER_HPP_


### PR DESCRIPTION
Open question: Do we move Configurable to its own header and make more `appfwk` classes inherit from it? Candidates include `DAQModuleManager` and `DAQModule`. Note that DAQModuleManager_test re-initializes DAQModuleManager with different ConfigurationManager instances, however this could probably be changed to use different DAQModuleManager instances...