### PR TITLE
Catch DAQModule init errors in DAQModuleManager, add the name of the

### DIFF
--- a/apps/daq_application.cxx
+++ b/apps/daq_application.cxx
@@ -81,15 +81,15 @@ main(int argc, char* argv[])
 
   // from now on, it's possible to use ERS messages
 
+  // Create the Application
+  appfwk::Application app(
+    args.app_name, args.session_name, args.command_facility_plugin_name, args.conf_service_plugin_name);
+
   try {
-    // Create the Application
-    appfwk::Application app(args.app_name, args.session_name,
-			    args.command_facility_plugin_name,
-			    args.conf_service_plugin_name);
     
     app.init();
     app.run(run_marker);
-  } catch ( const ers::Issue & e ) {
+  } catch ( ers::Issue & e ) {
     ers::fatal(appfwk::ApplicationFailure(ERS_HERE, args.session_name, args.app_name, e));
   }
 

--- a/include/appfwk/DAQModule.hpp
+++ b/include/appfwk/DAQModule.hpp
@@ -21,9 +21,9 @@
 
 #include "appfwk/ConfigurationManager.hpp"
 
-#include "utilities/NamedObject.hpp"
-#include "opmonlib/MonitorableObject.hpp"
 #include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "opmonlib/MonitorableObject.hpp"
+#include "utilities/NamedObject.hpp"
 
 #include "cetlib/BasicPluginFactory.h"
 #include "cetlib/compiler_macros.h"
@@ -78,6 +78,17 @@ ERS_DECLARE_ISSUE(appfwk,                 ///< Namespace
                   GeneralDAQModuleIssue,  ///< Issue class name
                   " DAQModule: " << name, ///< Message
                   ((std::string)name)     ///< Message parameters
+)
+
+/**
+ * @brief Initialization failed ERS Issue (used by DAQModuleManager)
+ */
+ERS_DECLARE_ISSUE_BASE(appfwk,                        ///< Namespace
+                       DAQModuleInitFailed,           ///< Type of the issue
+                       appfwk::GeneralDAQModuleIssue, ///< Base class of the issue
+                       " init failed.",               ///< Log message from the issue
+                       ((std::string)name),           ///< Base class attributes
+                       ERS_EMPTY                      ///< Attribute of this class
 )
 
 /**
@@ -161,7 +172,9 @@ namespace appfwk {
  * This header also contains the definitions of the Issues that can be
  * thrown by the DAQModule.
  */
-  class DAQModule : public utilities::NamedObject, public opmonlib::MonitorableObject
+class DAQModule
+  : public utilities::NamedObject
+  , public opmonlib::MonitorableObject
 {
 public:
   using data_t = nlohmann::json;

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -122,7 +122,12 @@ DAQModuleManager::init_modules(const std::vector<const dunedaq::confmodel::DaqMo
     m_modules_by_type[mod->class_name()].emplace_back(mod->UID());
 
     opm.register_node(mod->UID(), mptr);
-    mptr->init(m_configuration_mgr);
+
+    try {
+      mptr->init(m_configuration_mgr);
+    } catch (ers::Issue& ex) {
+      throw DAQModuleInitFailed(ERS_HERE, mod->UID(), ex);
+    }
   }
 }
 


### PR DESCRIPTION
failing module. Add new Issue type to DAQModule.hpp to carry this information.

Move Application constructor outside of try..catch block in daq_application, apparently the destructor of Application was interfering with the ers::fatal report of the issue which caused its destruction.