### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appfwk VERSION 4.1.0)
+project(appfwk VERSION 4.2.0)
 
 find_package(daq-cmake REQUIRED )
 

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -60,7 +60,7 @@ ConfigurationManager::initialize()
   if (smart_daq_app) {
     auto cpos = m_oks_config_spec.find(":") + 1;
     std::string oksFile = m_oks_config_spec.substr(cpos); // Strip off "oksconflibs:"
-    m_modules = smart_daq_app->generate_modules(m_confdb.get(), oksFile, m_session);
+    m_modules = smart_daq_app->generate_modules(m_session);
 
     for (auto& plan : smart_daq_app->get_action_plans()) {
       auto cmd = plan->get_command()->get_cmd();


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.
