### PR TITLE
Johnfreeman/new daq cmake for v5.3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(APPFWK_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging cmd
   confmodel::confmodel appmodel::appmodel conffwk::conffwk okssystem::okssystem)
 
 find_package(oksdalgen REQUIRED)
-add_dal_library(appfwk.schema.xml TEST NAMESPACE dunedaq::appfwk::dal
+daq_add_dal_library(appfwk.schema.xml TEST NAMESPACE dunedaq::appfwk::dal
   DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( cmd.jsonnet DEP_PKGS rcif cmdlib TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(APPFWK_DEPENDENCIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging cmd
   confmodel::confmodel appmodel::appmodel conffwk::conffwk okssystem::okssystem)
 
 find_package(oksdalgen REQUIRED)
-daq_oks_codegen(appfwk.schema.xml TEST NAMESPACE dunedaq::appfwk::dal
+add_dal_library(appfwk.schema.xml TEST NAMESPACE dunedaq::appfwk::dal
   DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( cmd.jsonnet DEP_PKGS rcif cmdlib TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )


### PR DESCRIPTION
The following PR enables this package to build on its patch branch against `daq-cmake` `v3.1.0`, which contains changes described in DUNE-DAQ/daq-cmake#155. 

This is only to be merged by Software Coordination. 