### PR TITLE
Improve ConfigurationManager and DAQModuleManager API for ActionPlan validation

### DIFF
--- a/include/appfwk/ConfigurationManager.hpp
+++ b/include/appfwk/ConfigurationManager.hpp
@@ -12,6 +12,8 @@
 #ifndef APPFWK_INCLUDE_APPFWK_CONFIGURATIONMANAGER_HPP_
 #define APPFWK_INCLUDE_APPFWK_CONFIGURATIONMANAGER_HPP_
 
+#include "appfwk/ValidationReport.hpp"
+
 #include "conffwk/Configuration.hpp"
 #include "confmodel/ActionPlan.hpp"
 #include "confmodel/Application.hpp"
@@ -27,6 +29,7 @@
 
 namespace dunedaq {
 
+// Disable coverage collection LCOV_EXCL_START
 ERS_DECLARE_ISSUE(appfwk,
                   NotADaqApplication,
                   "Application " << app << " is neither a DaqApplication nor a SmartDaqApplication ",
@@ -38,6 +41,7 @@ ERS_DECLARE_ISSUE(appfwk,
                   ActionPlanValidationFailed,
                   "Action plan validation failed: " << cmd << ", module " << module << ": " << message,
                   ((std::string)cmd)((std::string)module)((std::string)message))
+// Re-enable coverage collection LCOV_EXCL_STOP
 
 namespace appfwk {
 
@@ -45,7 +49,7 @@ class ConfigurationManager
 {
 public:
   ConfigurationManager(std::string const& config_spec, std::string const& app_name, std::string const& session_name);
-  void initialize();
+  std::vector<ValidationReport> initialize(bool throw_on_fatal = true);
 
   const confmodel::Session* get_session() const { return m_session; }
   const confmodel::Application* get_application()
@@ -87,6 +91,8 @@ public:
   {
     return m_confdb->get<T>(name);
   }
+
+  std::string get_app_name() const { return m_app_name; }
 
 private:
   std::shared_ptr<conffwk::Configuration> m_confdb;

--- a/include/appfwk/ValidationReport.hpp
+++ b/include/appfwk/ValidationReport.hpp
@@ -1,0 +1,74 @@
+/**
+ * @file ValidationReport.hpp Container for ActionPlan validation messages
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef APPFWK_INCLUDE_APPFWK_VALIDATIONREPORT_HPP_
+#define APPFWK_INCLUDE_APPFWK_VALIDATIONREPORT_HPP_
+
+#include <string>
+
+namespace dunedaq {
+
+
+namespace appfwk {
+
+class ValidationReport
+{
+public:
+  enum Severity
+  {
+    Fatal,
+    Error,
+    Warning,
+    Info,
+    Ignored
+  };
+
+  ValidationReport(Severity sev, std::string app, std::string module, std::string command, std::string message)
+    : m_severity(sev)
+    , m_app(app)
+    , m_module(module)
+    , m_command(command)
+    , m_message(message)
+  {
+  }
+
+  std::string severity_string()
+  {
+    switch (m_severity) {
+      case Severity::Fatal:
+        return "Fatal";
+      case Severity::Error:
+        return "Error";
+      case Severity::Warning:
+        return "Warning";
+      case Severity::Info:
+        return "Info";
+      case Severity::Ignored:
+        return "Debug";
+    }
+    return "UNKNOWN";
+  }
+
+  Severity get_severity() const { return m_severity; }
+  std::string get_app() const { return m_app; }
+  std::string get_module() const { return m_module; }
+  std::string get_command() const { return m_command; }
+  std::string get_message() const { return m_message; }
+
+private:
+  Severity m_severity;
+  std::string m_app;
+  std::string m_module;
+  std::string m_command;
+  std::string m_message;
+};
+
+} // namespace appfwk
+} //namespace dunedaq
+
+#endif // APPFWK_INCLUDE_APPFWK_VALIDATIONREPORT_HPP_

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -54,11 +54,12 @@ ConfigurationManager::ConfigurationManager(std::string const& config_spec,
   }
 }
 
-void
-ConfigurationManager::initialize()
+std::vector<ValidationReport>
+ConfigurationManager::initialize(bool throw_on_fatal)
 {
+  std::vector<ValidationReport> reports;
   if (m_initialized) {
-    return;
+    return reports;
   }
   TLOG_DBG(TLVL_APP) << "getting app " << m_app_name;
   m_application = m_confdb->get<confmodel::Application>(m_app_name);
@@ -69,6 +70,8 @@ ConfigurationManager::initialize()
 
   TLOG_DBG(TLVL_APP) << "getting modules for app " << m_app_name;
   auto smart_daq_app = m_application->cast<appmodel::SmartDaqApplication>();
+  auto daq_app = m_application->cast<confmodel::DaqApplication>();
+
   if (smart_daq_app) {
     auto cpos = m_oks_config_spec.find(":") + 1;
     std::string oksFile = m_oks_config_spec.substr(cpos); // Strip off "oksconflibs:"
@@ -78,28 +81,43 @@ ConfigurationManager::initialize()
       auto cmd = plan->get_command()->get_cmd();
       TLOG_DBG(TLVL_ACTION_PLAN) << "Registering action plan " << plan->UID() << " for cmd " << cmd;
       if (m_action_plans.count(cmd)) {
-        throw ActionPlanValidationFailed(
-          ERS_HERE, cmd, "N/A", "Multiple ActionPlans registered for cmd, conflicting plan is " + plan->UID());
+        reports.emplace_back(ValidationReport::Severity::Fatal,
+                             m_app_name,
+                             "N/A",
+                             cmd,
+                             "Multiple ActionPlans registered for cmd, conflicting plan is " + plan->UID());
+        if (throw_on_fatal)
+          throw ActionPlanValidationFailed(
+            ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message());
+        else
+          ers::error(ActionPlanValidationFailed(
+            ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message()));
+      }
+      m_action_plans[cmd] = plan;
+    }
+  } else if (daq_app) {
+    m_modules = daq_app->get_modules();
+
+    for (auto& plan : daq_app->get_action_plans()) {
+      auto cmd = plan->get_command()->get_cmd();
+      TLOG_DBG(TLVL_ACTION_PLAN) << "Registering action plan " << plan->UID() << " for cmd " << cmd;
+      if (m_action_plans.count(cmd)) {
+        reports.emplace_back(ValidationReport::Severity::Fatal,
+                             m_app_name,
+                             "N/A",
+                             cmd,
+                             "Multiple ActionPlans registered for cmd, conflicting plan is " + plan->UID());
+        if (throw_on_fatal)
+          throw ActionPlanValidationFailed(
+            ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message());
+        else
+          ers::error(ActionPlanValidationFailed(
+            ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message()));
       }
       m_action_plans[cmd] = plan;
     }
   } else {
-    auto daq_app = m_application->cast<confmodel::DaqApplication>();
-    if (daq_app) {
-      m_modules = daq_app->get_modules();
-
-      for (auto& plan : daq_app->get_action_plans()) {
-        auto cmd = plan->get_command()->get_cmd();
-        TLOG_DBG(TLVL_ACTION_PLAN) << "Registering action plan " << plan->UID() << " for cmd " << cmd;
-        if (m_action_plans.count(cmd)) {
-          throw ActionPlanValidationFailed(
-            ERS_HERE, cmd, "N/A", "Multiple ActionPlans registered for cmd, conflicting plan is " + plan->UID());
-        }
-        m_action_plans[cmd] = plan;
-      }
-    } else {
-      throw(NotADaqApplication(ERS_HERE, m_application->UID()));
-    }
+    throw(NotADaqApplication(ERS_HERE, m_application->UID()));
   }
 
   m_connsvc_config = m_session->get_connectivity_service();
@@ -129,6 +147,7 @@ ConfigurationManager::initialize()
   }
 
   m_initialized = true;
+  return reports;
 }
 
 const dunedaq::confmodel::ActionPlan*

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -40,7 +40,7 @@ DAQModuleManager::DAQModuleManager(const std::string& session_name)
 void
 DAQModuleManager::initialize(std::shared_ptr<ConfigurationManager> cfgMgr, opmonlib::OpMonManager& opm)
 {
-  m_configuration_mgr = cfgMgr; // Make a copy
+  set_config_mgr(cfgMgr);
   cfgMgr->initialize();
   get_iomanager()->configure(m_session_name,
                              m_configuration_mgr->get_queues(),
@@ -49,59 +49,51 @@ DAQModuleManager::initialize(std::shared_ptr<ConfigurationManager> cfgMgr, opmon
                              opm);
   init_modules(m_configuration_mgr->get_modules(), opm);
 
-  for (auto& plan_pair : m_configuration_mgr->get_action_plans()) {
-    auto cmd = plan_pair.first;
-    std::map<std::string, std::set<std::string>> modules_with_cmd;
-    for (const auto& [mod_type, module_list] : m_modules_by_type) {
-      if (module_list.size() > 0 && m_module_map[module_list[0]]->has_command(cmd)) {
-        modules_with_cmd[mod_type] = std::set<std::string>(module_list.begin(), module_list.end());
-      }
-    }
+  validate_action_plans();
 
-    for (auto& step : plan_pair.second->get_steps()) {
-      auto byType = step->cast<confmodel::DaqModulesGroupByType>();
-      auto byMod = step->cast<confmodel::DaqModulesGroupById>();
-      if (byType != nullptr) {
-        for (auto& mod_type : byType->get_modules()) {
-          check_mod_has_cmd(cmd, mod_type, byType->get_optional());
-          modules_with_cmd.erase(mod_type);
-        }
-      } else if (byMod != nullptr) {
-        for (auto& mod : byMod->get_modules()) {
-          check_mod_has_cmd(cmd, mod->class_name(), byMod->get_optional(), mod->UID());
-          modules_with_cmd[mod->class_name()].erase(mod->UID());
-        }
-      } else {
-        throw ActionPlanValidationFailed(ERS_HERE, cmd, "", "Invalid subclass of DaqModulesGroup encountered!");
-      }
-    }
-
-    for (const auto& [mod_type, module_list] : modules_with_cmd) {
-      for (auto& mod : module_list) {
-        ers::error(ActionPlanValidationFailed(
-          ERS_HERE, cmd, mod, "ActionPlan is defined, module has command, but module is not in any steps"));
-      }
-    }
-  }
   this->m_initialized = true;
 }
 
-void
+std::optional<ValidationReport>
 DAQModuleManager::check_mod_has_cmd(const std::string& cmd,
                                     const std::string& mod_class,
                                     bool is_optional,
-                                    const std::string& mod_id)
+                                    const std::string& mod_id,
+                                    bool throw_on_fatal)
 {
+  std::string app = m_configuration_mgr->get_app_name();
+
   if (!m_modules_by_type.count(mod_class) || m_modules_by_type[mod_class].size() == 0) {
-    if (is_optional)
-      return;
+    if (is_optional) {
+      ValidationReport report(ValidationReport::Severity::Ignored,
+                           app,
+                           mod_class,
+                           cmd,
+                           "No modules of class " + mod_class + " in application (optional step)");
+
+      return report;
+    }
     if (mod_id == "") {
-      ers::warning(
-        ActionPlanValidationFailed(ERS_HERE, cmd, mod_class, "No modules of class " + mod_class + " in application!"));
-      return;
+      ValidationReport report(ValidationReport::Severity::Warning,
+                           app,
+                           mod_class,
+                           cmd,
+                           "No modules of class " + mod_class + " in application!");
+      ers::warning(ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
+      return report;
     } else {
-      throw ActionPlanValidationFailed(
-        ERS_HERE, cmd, mod_class, "No modules of class " + mod_class + " in application!");
+      ValidationReport report(ValidationReport::Severity::Fatal,
+                           app,
+                           mod_class,
+                           cmd,
+                           "No modules of class " + mod_class + " in application!");
+      if (throw_on_fatal)
+        throw ActionPlanValidationFailed(
+          ERS_HERE, report.get_command(), report.get_module(), report.get_message());
+      else
+        ers::error(ActionPlanValidationFailed(
+          ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
+      return report;
     }
   }
 
@@ -116,18 +108,33 @@ DAQModuleManager::check_mod_has_cmd(const std::string& cmd,
       }
     }
     if (!match && !is_optional) {
-      throw ActionPlanValidationFailed(ERS_HERE, cmd, mod_class, "No module with id " + mod_id + " found.");
+      ValidationReport report(
+        ValidationReport::Severity::Fatal, app, mod_class, cmd, "No module with id " + mod_id + " found.");
+
+      if (throw_on_fatal)
+        throw ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message());
+      else
+        ers::error(
+          ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
+      return report;
     }
   }
 
   if (!module_test->has_command(cmd)) {
-    throw ActionPlanValidationFailed(ERS_HERE, cmd, mod_class, "Module does not have command " + cmd + " registered.");
+    ValidationReport report(
+      ValidationReport::Severity::Fatal, app, mod_class, cmd, "Module does not have command " + cmd + " registered.");
+
+    if (throw_on_fatal)
+      throw ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message());
+    else
+      ers::error(ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
+    return report;
   }
+  return {};
 }
 
 void
-DAQModuleManager::init_modules(const std::vector<const dunedaq::confmodel::DaqModule*>& modules,
-                               opmonlib::OpMonManager& opm)
+DAQModuleManager::construct_modules(const std::vector<const dunedaq::confmodel::DaqModule*>& modules)
 {
   for (const auto mod : modules) {
     TLOG_DEBUG(0) << "construct: " << mod->class_name() << " : " << mod->UID();
@@ -140,7 +147,17 @@ DAQModuleManager::init_modules(const std::vector<const dunedaq::confmodel::DaqMo
       m_modules_by_type[mod->class_name()] = std::vector<std::string>();
     }
     m_modules_by_type[mod->class_name()].emplace_back(mod->UID());
+  }
+}
 
+void
+DAQModuleManager::init_modules(const std::vector<const dunedaq::confmodel::DaqModule*>& modules,
+                               opmonlib::OpMonManager& opm)
+{
+  construct_modules(modules);
+
+  for (const auto mod : modules) {
+    auto mptr = m_module_map[mod->UID()];
     opm.register_node(mod->UID(), mptr);
 
     try {
@@ -149,6 +166,67 @@ DAQModuleManager::init_modules(const std::vector<const dunedaq::confmodel::DaqMo
       throw DAQModuleInitFailed(ERS_HERE, mod->UID(), ex);
     }
   }
+}
+
+std::vector<ValidationReport>
+DAQModuleManager::validate_action_plans(bool throw_on_fatal)
+{
+  std::vector<ValidationReport> reports;
+  std::string app = m_configuration_mgr->get_app_name();
+
+  for (auto& plan_pair : m_configuration_mgr->get_action_plans()) {
+    auto cmd = plan_pair.first;
+    TLOG_DEBUG(0) << app << ": Checking action plan " << cmd;
+    std::map<std::string, std::set<std::string>> modules_with_cmd;
+    for (const auto& [mod_type, module_list] : m_modules_by_type) {
+      if (module_list.size() > 0 && m_module_map[module_list[0]]->has_command(cmd)) {
+        modules_with_cmd[mod_type] = std::set<std::string>(module_list.begin(), module_list.end());
+      }
+    }
+
+    for (auto& step : plan_pair.second->get_steps()) {
+      auto byType = step->cast<confmodel::DaqModulesGroupByType>();
+      auto byMod = step->cast<confmodel::DaqModulesGroupById>();
+      if (byType != nullptr) {
+        for (auto& mod_type : byType->get_modules()) {
+          auto report = check_mod_has_cmd(cmd, mod_type, byType->get_optional(), "", throw_on_fatal);
+          if (report)
+            reports.push_back(report.value());
+          modules_with_cmd.erase(mod_type);
+        }
+      } else if (byMod != nullptr) {
+        for (auto& mod : byMod->get_modules()) {
+          auto report = check_mod_has_cmd(cmd, mod->class_name(), byMod->get_optional(), mod->UID(), throw_on_fatal);
+          if (report)
+            reports.push_back(report.value());
+          modules_with_cmd[mod->class_name()].erase(mod->UID());
+        }
+      } else {
+        reports.emplace_back(
+          ValidationReport::Severity::Fatal, app, "N/A", cmd, "Invalid subclass of DaqModulesGroup encountered!");
+        if (throw_on_fatal)
+          throw ActionPlanValidationFailed(
+            ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message());
+        else
+          ers::error(ActionPlanValidationFailed(
+            ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message()));
+      }
+    }
+
+    for (const auto& [mod_type, module_list] : modules_with_cmd) {
+      for (auto& mod : module_list) {
+        reports.emplace_back(ValidationReport::Severity::Error,
+                             app,
+                             mod_type,
+                             cmd,
+                             "ActionPlan is defined, module has command, but module " + mod + " is not in any steps");
+        ers::error(ActionPlanValidationFailed(
+          ERS_HERE, reports.back().get_command(), reports.back().get_module(), reports.back().get_message()));
+      }
+    }
+  }
+
+  return reports;
 }
 
 void
@@ -183,7 +261,9 @@ DAQModuleManager::get_command_data_for_module(const std::string& mod_name, const
 }
 
 bool
-DAQModuleManager::execute_action(const std::string& module_name, const std::string& action, const DAQModule::CommandData_t& command_data)
+DAQModuleManager::execute_action(const std::string& module_name,
+                                 const std::string& action,
+                                 const DAQModule::CommandData_t& command_data)
 {
   try {
     TLOG_DEBUG(2) << "Executing " << module_name << " -> " << action;

--- a/src/DAQModuleManager.hpp
+++ b/src/DAQModuleManager.hpp
@@ -12,8 +12,9 @@
 #include "ers/Issue.hpp"
 #include "nlohmann/json.hpp"
 
-#include "appfwk/DAQModule.hpp"
 #include "appfwk/ConfigurationManager.hpp"
+#include "appfwk/DAQModule.hpp"
+#include "appfwk/ValidationReport.hpp"
 #include "conffwk/Configuration.hpp"
 #include "confmodel/DaqModule.hpp"
 
@@ -82,6 +83,11 @@ public:
   // Execute a properly structured command
   void execute(const std::string& cmd, const DAQModule::CommandData_t& cmd_data);
 
+  // Used during ActionPlan validation
+  void set_config_mgr(std::shared_ptr<ConfigurationManager> mgr) { m_configuration_mgr = mgr; }
+  void construct_modules(const std::vector<const dunedaq::confmodel::DaqModule*>& modules);
+  std::vector<ValidationReport> validate_action_plans(bool throw_on_fatal = true);
+
 private:
   typedef std::map<std::string, std::shared_ptr<DAQModule>> DAQModuleMap_t; ///< DAQModules indexed by name
 
@@ -89,17 +95,18 @@ private:
 
   void check_command_data(const std::string& id, const DAQModule::CommandData_t& cmd_data);
   DAQModule::CommandData_t get_command_data_for_module(const std::string& mod_name,
-                                                  const DAQModule::CommandData_t& cmd_data);
+                                                       const DAQModule::CommandData_t& cmd_data);
   bool execute_action(const std::string& mod_name, const std::string& action, const DAQModule::CommandData_t& data_obj);
   void execute_action_plan_step(const std::string& cmd,
                                 const confmodel::DaqModulesGroup* step,
                                 const DAQModule::CommandData_t& cmd_data,
                                 bool execution_mode_is_serial);
 
-  void check_mod_has_cmd(const std::string& cmd,
-                         const std::string& mod_class,
-                         bool is_optional,
-                         const std::string& mod_id = "");
+  std::optional<ValidationReport> check_mod_has_cmd(const std::string& cmd,
+                                                  const std::string& mod_class,
+                                                  bool is_optional,
+                                                  const std::string& mod_id,
+                                                  bool throw_on_fatal);
 
   std::vector<std::string> get_modnames_by_cmdid(cmdlib::cmd::CmdId id);
   std::shared_ptr<ConfigurationManager> m_configuration_mgr;

--- a/test/apps/check_action_plans.cxx
+++ b/test/apps/check_action_plans.cxx
@@ -13,6 +13,7 @@
 #include "DAQModuleManager.hpp"
 #include "appfwk/ConfigurationManager.hpp"
 #include "appfwk/DAQModule.hpp"
+#include "appfwk/ValidationReport.hpp"
 
 #include "conffwk/Configuration.hpp"
 #include "confmodel/DaqModulesGroup.hpp"
@@ -30,116 +31,30 @@
 
 using namespace dunedaq;
 
-std::map<std::string, std::shared_ptr<appfwk::DAQModule>> module_map;
-std::map<std::string, std::vector<std::string>> modules_by_type;
-
 std::string red = "";    // NOLINT
 std::string green = "";  // NOLINT
 std::string yellow = ""; // NOLINT
 std::string blue = "";   // NOLINT
 std::string clear = "";  // NOLINT
 
-struct ErrorReport
+std::string
+severity_color(appfwk::ValidationReport report)
 {
-  enum Severity
-  {
-    Error,
-    Warning,
-    Info,
-    Ignored
-  };
-  Severity severity;
-  std::string app;
-  std::string module;
-  std::string command;
-  std::string message;
-
-  std::string severity_color()
-  {
-    switch (severity) {
-      case ErrorReport::Severity::Error:
-        return red;
-      case ErrorReport::Severity::Warning:
-        return yellow;
-      case ErrorReport::Severity::Info:
-        return blue;
-      case ErrorReport::Severity::Ignored:
-        return green;
-    }
-    return clear;
+  switch (report.get_severity()) {
+    case appfwk::ValidationReport::Severity::Fatal:
+      return red;
+    case appfwk::ValidationReport::Severity::Error:
+      return red;
+    case appfwk::ValidationReport::Severity::Warning:
+      return yellow;
+    case appfwk::ValidationReport::Severity::Info:
+      return blue;
+    case appfwk::ValidationReport::Severity::Ignored:
+      return green;
   }
-  std::string severity_string()
-  {
-    switch (severity) {
-      case ErrorReport::Severity::Error:
-        return "Error";
-      case ErrorReport::Severity::Warning:
-        return "Warning";
-      case ErrorReport::Severity::Info:
-        return "Info";
-      case ErrorReport::Severity::Ignored:
-        return "Debug";
-    }
-    return "UNKNOWN";
-  }
-};
-std::vector<ErrorReport> validation_errors;
-
-void
-check_mod_has_cmd(const std::string& app,
-                  const std::string& cmd,
-                  const std::string& mod_class,
-                  bool is_optional,
-                  const std::string& mod_id = "")
-{
-  if (!modules_by_type.count(mod_class) || modules_by_type[mod_class].size() == 0) {
-    if (is_optional) {
-      validation_errors.emplace_back(ErrorReport::Severity::Ignored,
-                                     app,
-                                     mod_class,
-                                     cmd,
-                                     "No modules of class " + mod_class + " in application (optional step)");
-      return;
-    }
-    if (mod_id == "") {
-      validation_errors.emplace_back(
-        ErrorReport::Severity::Warning, app, mod_class, cmd, "No modules of class " + mod_class + " in application!");
-      ers::warning(appfwk::ActionPlanValidationFailed(
-        ERS_HERE, cmd, mod_class, "No modules of class " + mod_class + " in application!"));
-      return;
-    } else {
-      validation_errors.emplace_back(
-        ErrorReport::Severity::Error, app, mod_class, cmd, "No modules of class " + mod_class + " in application!");
-      ers::error(appfwk::ActionPlanValidationFailed(
-        ERS_HERE, cmd, mod_class, "No modules of class " + mod_class + " in application!"));
-    }
-  }
-
-  auto module_test = module_map[modules_by_type[mod_class][0]];
-  if (mod_id != "") {
-    bool match = false;
-    for (auto& mod_name : modules_by_type[mod_class]) {
-      if (mod_id == mod_name) {
-        module_test = module_map[mod_name];
-        match = true;
-        break;
-      }
-    }
-    if (!match && !is_optional) {
-      validation_errors.emplace_back(
-        ErrorReport::Severity::Error, app, mod_class, cmd, "No module with id " + mod_id + " found.");
-      ers::error(
-        appfwk::ActionPlanValidationFailed(ERS_HERE, cmd, mod_class, "No module with id " + mod_id + " found."));
-    }
-  }
-
-  if (!module_test->has_command(cmd)) {
-    validation_errors.emplace_back(
-      ErrorReport::Severity::Error, app, mod_class, cmd, "Module does not have command " + cmd + " registered.");
-    ers::error(appfwk::ActionPlanValidationFailed(
-      ERS_HERE, cmd, mod_class, "Module does not have command " + cmd + " registered."));
-  }
+  return clear;
 }
+
 int
 main(int argc, char* argv[])
 {
@@ -191,72 +106,29 @@ main(int argc, char* argv[])
 
   auto apps = session->enabled_applications();
 
+  std::vector<appfwk::ValidationReport> validation_errors;
+
   for (auto& app : apps) {
-    module_map.clear();
-    modules_by_type.clear();
 
     TLOG() << app->UID() << ": Initializing ConfigurationManager to check for duplicate ActionPlans";
     auto cfgMgr = std::make_shared<appfwk::ConfigurationManager>(dbfile, app->UID(), sessionName);
-    cfgMgr->initialize();
+    auto cfgMgr_reports = cfgMgr->initialize(false);
+    validation_errors.insert(validation_errors.end(),
+                             std::make_move_iterator(cfgMgr_reports.begin()),
+                             std::make_move_iterator(cfgMgr_reports.end()));
 
     // Check module matching
+    TLOG() << app->UID() << ": Constructing modules so they can register their commands";
     auto modules = cfgMgr->get_modules();
+    appfwk::DAQModuleManager mmgr(sessionName);
+    mmgr.set_config_mgr(cfgMgr);
+    mmgr.construct_modules(modules);
 
-    for (const auto mod : modules) {
-      TLOG_DEBUG(0) << "construct: " << mod->class_name() << " : " << mod->UID();
-      auto mptr = appfwk::make_module(mod->class_name(), mod->UID());
-      module_map.emplace(mod->UID(), mptr);
-
-      if (!modules_by_type.count(mod->class_name())) {
-        modules_by_type[mod->class_name()] = std::vector<std::string>();
-      }
-      modules_by_type[mod->class_name()].emplace_back(mod->UID());
-    }
-
-    for (auto& plan_pair : cfgMgr->get_action_plans()) {
-      auto cmd = plan_pair.first;
-      TLOG() << app->UID() << ": Checking action plan " << cmd;
-      std::map<std::string, std::set<std::string>> modules_with_cmd;
-      for (const auto& [mod_type, module_list] : modules_by_type) {
-        if (module_list.size() > 0 && module_map[module_list[0]]->has_command(cmd)) {
-          modules_with_cmd[mod_type] = std::set<std::string>(module_list.begin(), module_list.end());
-        }
-      }
-
-      for (auto& step : plan_pair.second->get_steps()) {
-        auto byType = step->cast<confmodel::DaqModulesGroupByType>();
-        auto byMod = step->cast<confmodel::DaqModulesGroupById>();
-        if (byType != nullptr) {
-          for (auto& mod_type : byType->get_modules()) {
-            check_mod_has_cmd(app->UID(), cmd, mod_type, byType->get_optional());
-            modules_with_cmd.erase(mod_type);
-          }
-        } else if (byMod != nullptr) {
-          for (auto& mod : byMod->get_modules()) {
-            check_mod_has_cmd(app->UID(), cmd, mod->class_name(), byMod->get_optional(), mod->UID());
-            modules_with_cmd[mod->class_name()].erase(mod->UID());
-          }
-        } else {
-          validation_errors.emplace_back(
-            ErrorReport::Severity::Error, app->UID(), "N/A", cmd, "Invalid subclass of DaqModulesGroup encountered!");
-          ers::error(
-            appfwk::ActionPlanValidationFailed(ERS_HERE, cmd, "", "Invalid subclass of DaqModulesGroup encountered!"));
-        }
-      }
-
-      for (const auto& [mod_type, module_list] : modules_with_cmd) {
-        for (auto& mod : module_list) {
-          validation_errors.emplace_back(ErrorReport::Severity::Error,
-                                         app->UID(),
-                                         mod_type,
-                                         cmd,
-                                         "ActionPlan is defined, module has command, but module " + mod +
-                                           " is not in any steps");
-          ers::error(appfwk::ActionPlanValidationFailed(
-            ERS_HERE, cmd, mod, "ActionPlan is defined, module has command, but module is not in any steps"));
-        }
-      }
-    }
+    
+    TLOG() << app->UID() << ": Validating Action Plans";
+    auto ap_reports = mmgr.validate_action_plans(false);
+    validation_errors.insert(validation_errors.end(),
+                             std::make_move_iterator(ap_reports.begin()), std::make_move_iterator(ap_reports.end()));
   }
 
   std::cout << std::endl << std::endl << "Summary:" << std::endl; // NOLINT
@@ -268,12 +140,12 @@ main(int argc, char* argv[])
     size_t longest_severity = 8; // Severity heading
 
     for (auto& report : validation_errors) {
-      if (report.app.size() > longest_app)
-        longest_app = report.app.size();
-      if (report.command.size() > longest_command)
-        longest_command = report.command.size();
-      if (report.module.size() > longest_module)
-        longest_module = report.module.size();
+      if (report.get_app().size() > longest_app)
+        longest_app = report.get_app().size();
+      if (report.get_command().size() > longest_command)
+        longest_command = report.get_command().size();
+      if (report.get_module().size() > longest_module)
+        longest_module = report.get_module().size();
     }
 
     std::string app_heading_space(longest_app - 11 + minimum_space, ' ');
@@ -286,16 +158,16 @@ main(int argc, char* argv[])
 
     for (auto& report : validation_errors) {
 
-      std::cout << report.severity_color(); // NOLINT
-      std::string app_space(longest_app - report.app.size() + minimum_space, ' ');
-      std::cout << report.app << app_space; // NOLINT
-      std::string command_space(longest_command - report.command.size() + minimum_space, ' ');
-      std::cout << report.command << command_space; // NOLINT
-      std::string module_space(longest_module - report.module.size() + minimum_space, ' ');
-      std::cout << report.module << module_space; // NOLINT
+      std::cout << severity_color(report); // NOLINT
+      std::string app_space(longest_app - report.get_app().size() + minimum_space, ' ');
+      std::cout << report.get_app() << app_space; // NOLINT
+      std::string command_space(longest_command - report.get_command().size() + minimum_space, ' ');
+      std::cout << report.get_command() << command_space; // NOLINT
+      std::string module_space(longest_module - report.get_module().size() + minimum_space, ' ');
+      std::cout << report.get_module() << module_space; // NOLINT
       std::string severity_space(longest_severity - report.severity_string().size() + minimum_space, ' ');
       std::cout << report.severity_string() << severity_space; // NOLINT
-      std::cout << report.message << clear << std::endl;       // NOLINT
+      std::cout << report.get_message() << clear << std::endl;       // NOLINT
     }
   } else {
     std::cout << "No validation errors encountered!" << std::endl; // NOLINT


### PR DESCRIPTION
Validation can be run without initializing DAQModules. Create ValidationReports in addition to ers Issues, so that check_action_plans can use DAQModuleManager API to validate ActionPlans without reimplementing validation logic.

Resolves #349