### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appfwk VERSION 6.0.0)
+project(appfwk VERSION 6.0.1)
 
 find_package(daq-cmake REQUIRED )
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -113,31 +113,14 @@ Application::execute(const dataobj_t& cmd_data)
     m_error.store(true);
     throw;
   }
+
+  publish_app_info();
 }
 
 void
 Application::generate_opmon_data()
 {
-  opmon::AppInfo ai;
-  ai.set_state(get_state());
-  ai.set_busy(m_busy.load());
-  ai.set_error(m_error.load());
-
-  char hostname[256]; // NOLINT
-  auto res = gethostname(hostname, 256);
-  if (res < 0)
-    ai.set_host("Unknown");
-  else
-    ai.set_host(std::string(hostname));
-
-  publish(std::move(ai), {}, opmonlib::to_level(opmonlib::EntryOpMonLevel::kTopPriority));
-
-  if (m_run_start_time.time_since_epoch().count() != 0) {
-    auto now = std::chrono::steady_clock::now();
-    m_runinfo.set_run_time(std::chrono::duration_cast<std::chrono::seconds>(now - m_run_start_time).count());
-  }
-
-  publish(decltype(m_runinfo)(m_runinfo));
+  publish_app_info();
 }
 
 bool
@@ -153,4 +136,31 @@ Application::check_state_for_cmd(const dataobj_t& cmd_data) const
   return false;
 }
 
+void
+Application::publish_app_info() {
+  
+  opmon::AppInfo ai;
+  ai.set_state(get_state());
+  ai.set_busy(m_busy.load());
+  ai.set_error(m_error.load());
+  
+  char hostname[256]; // NOLINT
+  auto res = gethostname(hostname, 256);
+  if (res < 0)
+    ai.set_host("Unknown");
+  else
+    ai.set_host(std::string(hostname));
+
+  publish(std::move(ai), {}, opmonlib::to_level(opmonlib::EntryOpMonLevel::kTopPriority));
+
+  if (m_run_start_time.time_since_epoch().count() != 0) {
+    auto now = std::chrono::steady_clock::now();
+    m_runinfo.set_run_time(std::chrono::duration_cast<std::chrono::seconds>(now - m_run_start_time).count());
+  }
+
+  publish(decltype(m_runinfo)(m_runinfo));
+
+}
+
+  
 } // namespace dunedaq::appfwk

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -92,6 +92,9 @@ public:
     return m_state;
   }
 
+protected:
+  void publish_app_info();
+  
 private:
   DAQModuleManager m_mod_mgr;
   mutable std::mutex m_mutex;


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 




# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

