### PR TITLE
Add method to ConfigurationManager to add include of db file at run time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ daq_add_unit_test(Application_test            LINK_LIBRARIES appfwk )
 daq_add_unit_test(CommandLineInterpreter_test LINK_LIBRARIES appfwk )
 daq_add_unit_test(DAQModule_test              LINK_LIBRARIES appfwk )
 daq_add_unit_test(DAQModuleManager_test       LINK_LIBRARIES appfwk )
+daq_add_unit_test(ConfigurationManager_test   LINK_LIBRARIES appfwk )
 
 ##############################################################################
 

--- a/include/appfwk/ConfigurationManager.hpp
+++ b/include/appfwk/ConfigurationManager.hpp
@@ -33,7 +33,7 @@ namespace dunedaq {
 // Disable coverage collection LCOV_EXCL_START
 ERS_DECLARE_ISSUE(appfwk,
                   NotADaqApplication,
-                  "Application " << app << " is neither a DaqApplication nor a SmartDaqApplication ",
+                  "Application " << app << " is not a DaqApplication",
                   ((std::string)app))
 
 ERS_DECLARE_ISSUE(appfwk, MissingComponent, "No such component: " << what, ((std::string)what))
@@ -42,6 +42,10 @@ ERS_DECLARE_ISSUE(appfwk,
                   ActionPlanValidationFailed,
                   "Action plan validation failed: " << cmd << ", module " << module << ": " << message,
                   ((std::string)cmd)((std::string)module)((std::string)message))
+
+ERS_DECLARE_ISSUE(appfwk, FailedInclude, "Failed to include deferred database file: " << filename,
+                  ((std::string)filename))
+
 // Re-enable coverage collection LCOV_EXCL_STOP
 
 namespace appfwk {
@@ -95,11 +99,14 @@ public:
 
   std::string get_app_name() const { return m_app_name; }
 
+  void load_deferred_db(const std::string& dbname);
+
 private:
   std::shared_ptr<conffwk::Configuration> m_confdb;
   std::shared_ptr<appmodel::ConfigurationHelper> m_helper;
   std::string m_app_name;
   std::string m_session_name;
+  std::string m_config_spec;
 
   const confmodel::Session* m_session;
   const confmodel::DaqApplication* m_application;

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -42,6 +42,7 @@ ConfigurationManager::ConfigurationManager(std::string const& config_spec,
   : m_confdb(new conffwk::Configuration(config_spec))
   , m_app_name(app_name)
   , m_session_name(session_name)
+  , m_config_spec(config_spec)
 {
   TLOG() << "configSpec <" << config_spec << "> session name " << session_name << " application name " << app_name;
 
@@ -137,4 +138,19 @@ ConfigurationManager::get_action_plan(std::string cmd) const
     return m_action_plans.at(cmd);
   }
   return nullptr;
+}
+
+void
+ConfigurationManager::load_deferred_db(const std::string& include_name)
+{
+  auto pos = m_config_spec.find_last_of(":");
+  pos =  (pos == std::string::npos) ? 0 : pos + 1;
+  auto dbfile = m_config_spec.substr(pos);
+
+  try {
+    m_confdb->add_include(dbfile, include_name);
+  }
+  catch (const dunedaq::conffwk::Generic& except) {
+    throw(FailedInclude(ERS_HERE, include_name, except));
+  }
 }

--- a/test/config/dummyInclude.data.xml
+++ b/test/config/dummyInclude.data.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="1" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="latitude" creation-time="20260312T141954" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260312T145045"/>
+
+<include>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
+</include>
+
+
+<obj class="Variable" id="test-variable">
+ <attr name="description" type="string" val="variable for unit test"/>
+ <attr name="name" type="string" val="test"/>
+ <attr name="value" type="string" val="yes"/>
+</obj>
+
+</oks-data>

--- a/test/config/duplicateDummyInclude.data.xml
+++ b/test/config/duplicateDummyInclude.data.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="1" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="latitude" creation-time="20260312T141954" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260312T145045"/>
+
+<include>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
+</include>
+
+
+<obj class="Variable" id="test-variable">
+ <attr name="description" type="string" val="variable for unit test"/>
+ <attr name="name" type="string" val="test"/>
+ <attr name="value" type="string" val="yes"/>
+</obj>
+
+</oks-data>

--- a/unittest/ConfigurationManager_test.cxx
+++ b/unittest/ConfigurationManager_test.cxx
@@ -1,0 +1,52 @@
+/**
+ * @file ConfigurationManager_test.cxx ConfigurationManager_test class
+ * Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "appfwk/ConfigurationManager.hpp"
+#include "confmodel/Variable.hpp"
+
+#define BOOST_TEST_MODULE ConfigurationManager_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+using namespace dunedaq::appfwk;
+
+BOOST_AUTO_TEST_SUITE(ConfigurationManager_test)
+
+const std::string config_spec{"oksconflibs:test/config/appSession.data.xml"};
+const std::string appname{"TestApp"};
+const std::string session{"test-session"};
+
+BOOST_AUTO_TEST_CASE(Include)
+{
+  auto cm = std::make_shared<ConfigurationManager>(config_spec, appname, session);
+  cm->load_deferred_db("test/config/dummyInclude.data.xml");
+
+  auto variable = cm->get_dal<dunedaq::confmodel::Variable>("test-variable");
+  BOOST_REQUIRE(variable != nullptr);
+  BOOST_REQUIRE_EQUAL(variable->get_name(), "test");
+}
+BOOST_AUTO_TEST_CASE(IncludeTwice)
+{
+  auto cm = std::make_shared<ConfigurationManager>(config_spec, appname, session);
+  cm->load_deferred_db("test/config/dummyInclude.data.xml");
+  cm->load_deferred_db("test/config/dummyInclude.data.xml");
+
+  auto variable = cm->get_dal<dunedaq::confmodel::Variable>("test-variable");
+  BOOST_REQUIRE(variable != nullptr);
+  BOOST_REQUIRE_EQUAL(variable->get_name(), "test");
+}
+
+
+BOOST_AUTO_TEST_CASE(IncludeDuplicate)
+{
+  auto cm = std::make_shared<ConfigurationManager>(config_spec, appname, session);
+  cm->load_deferred_db("test/config/dummyInclude.data.xml");
+  BOOST_REQUIRE_THROW(cm->load_deferred_db("test/config/duplicateDummyInclude.data.xml"), FailedInclude);
+}
+}


### PR DESCRIPTION
# Description

Add a new method to `ConfigurationManager` to include a new file into the configuration db from user code. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

