### PR TITLE
Add error message when failing to load DAQModule plugins

### DIFF
--- a/include/appfwk/detail/DAQModule.hxx
+++ b/include/appfwk/detail/DAQModule.hxx
@@ -45,6 +45,7 @@ make_module(std::string const& plugin_name, std::string const& instance_name)
   try {
     mod_ptr = bpf.makePlugin<std::shared_ptr<DAQModule>>(plugin_name, instance_name);
   } catch (const cet::exception& cexpt) {
+    ers::error(DAQModuleCreationFailed(ERS_HERE, plugin_name, instance_name, cexpt));
     throw DAQModuleCreationFailed(ERS_HERE, plugin_name, instance_name, cexpt);
   }
   return mod_ptr;

--- a/unittest/DAQModule_test.cxx
+++ b/unittest/DAQModule_test.cxx
@@ -124,9 +124,14 @@ BOOST_AUTO_TEST_CASE(Commands)
 
 BOOST_AUTO_TEST_CASE(MakeModule)
 {
-  BOOST_REQUIRE_EXCEPTION(make_module("not_a_real_plugin_name", "error_test"),
-                          DAQModuleCreationFailed,
-                          [&](DAQModuleCreationFailed) { return true; });
+  BOOST_REQUIRE_EXCEPTION(
+    make_module("not_a_valid_plugin_name", "error_test"), DAQModuleCreationFailed, [&](DAQModuleCreationFailed e) {
+      return e.cause()->message().find("contains an illegal underscore") != std::string::npos;
+    });
+  BOOST_REQUIRE_EXCEPTION(
+    make_module("not-a-real-plugin-name", "error_test"), DAQModuleCreationFailed, [&](DAQModuleCreationFailed e) {
+      return e.cause()->message().find("does not correspond to any library") != std::string::npos;
+    });
 }
 
 BOOST_AUTO_TEST_CASE(RegisterCommand)


### PR DESCRIPTION
# Description

Add an ers::error report of DAQModuleCreationFailed to ensure output when running in unit tests.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

