### PR TITLE
Clang format DAQModuleManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ test/src/appfwk/fakedataconsumerdaqmodule/Structs.hpp
 .DS_Store
 
 # dbt-clang-format temporary files
-.clang-format
+.clang-format*

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -66,33 +66,33 @@ DAQModuleManager::check_mod_has_cmd(const std::string& cmd,
   if (!m_modules_by_type.count(mod_class) || m_modules_by_type[mod_class].size() == 0) {
     if (is_optional) {
       ValidationReport report(ValidationReport::Severity::Ignored,
-                           app,
-                           mod_class,
-                           cmd,
-                           "No modules of class " + mod_class + " in application (optional step)");
+                              app,
+                              mod_class,
+                              cmd,
+                              "No modules of class " + mod_class + " in application (optional step)");
 
       return report;
     }
     if (mod_id == "") {
       ValidationReport report(ValidationReport::Severity::Warning,
-                           app,
-                           mod_class,
-                           cmd,
-                           "No modules of class " + mod_class + " in application!");
-      ers::warning(ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
+                              app,
+                              mod_class,
+                              cmd,
+                              "No modules of class " + mod_class + " in application!");
+      ers::warning(
+        ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
       return report;
     } else {
       ValidationReport report(ValidationReport::Severity::Fatal,
-                           app,
-                           mod_class,
-                           cmd,
-                           "No modules of class " + mod_class + " in application!");
+                              app,
+                              mod_class,
+                              cmd,
+                              "No modules of class " + mod_class + " in application!");
       if (throw_on_fatal)
-        throw ActionPlanValidationFailed(
-          ERS_HERE, report.get_command(), report.get_module(), report.get_message());
+        throw ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message());
       else
-        ers::error(ActionPlanValidationFailed(
-          ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
+        ers::error(
+          ActionPlanValidationFailed(ERS_HERE, report.get_command(), report.get_module(), report.get_message()));
       return report;
     }
   }

--- a/src/DAQModuleManager.hpp
+++ b/src/DAQModuleManager.hpp
@@ -103,10 +103,10 @@ private:
                                 bool execution_mode_is_serial);
 
   std::optional<ValidationReport> check_mod_has_cmd(const std::string& cmd,
-                                                  const std::string& mod_class,
-                                                  bool is_optional,
-                                                  const std::string& mod_id,
-                                                  bool throw_on_fatal);
+                                                    const std::string& mod_class,
+                                                    bool is_optional,
+                                                    const std::string& mod_id,
+                                                    bool throw_on_fatal);
 
   std::vector<std::string> get_modnames_by_cmdid(cmdlib::cmd::CmdId id);
   std::shared_ptr<ConfigurationManager> m_configuration_mgr;


### PR DESCRIPTION
# Description

I'm making some small changes to the `DAQModuleManager` code as part of adding support for artificial delays in our test systems, and as part of that I would like to run `clang-format` on that code to ensure that my additions conform to the style guide.  However, it appears that there are some formatting changes that would be nice to make before I make my changes, so I'm submitting them here.

I also added a wildcard character to the end of the `.clang-format` line in the `.gitignore` file since it seems that `clang-format` now produces `.clang-format.previous` files.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
