### PR TITLE
Experimental code to try reloading configuration

### DIFF
--- a/include/appfwk/ConfigurationManager.hpp
+++ b/include/appfwk/ConfigurationManager.hpp
@@ -38,6 +38,8 @@ ERS_DECLARE_ISSUE(appfwk,
 
 ERS_DECLARE_ISSUE(appfwk, MissingComponent, "No such component: " << what, ((std::string)what))
 
+ERS_DECLARE_ISSUE(appfwk, ModuleListChanged, "List of modules has changed since init: " << what, ((std::string)what))
+
 ERS_DECLARE_ISSUE(appfwk,
                   ActionPlanValidationFailed,
                   "Action plan validation failed: " << cmd << ", module " << module << ": " << message,
@@ -51,6 +53,8 @@ class ConfigurationManager
 public:
   ConfigurationManager(std::string const& config_spec, std::string const& app_name, std::string const& session_name);
   std::vector<ValidationReport> initialize(bool throw_on_fatal = true);
+
+  void reload(const std::string& confspec);
 
   const confmodel::Session* get_session() const { return m_session; }
   const confmodel::Application* get_application()
@@ -98,6 +102,7 @@ public:
 private:
   std::shared_ptr<conffwk::Configuration> m_confdb;
   std::shared_ptr<appmodel::ConfigurationHelper> m_helper;
+  std::string m_config_spec;
   std::string m_app_name;
   std::string m_session_name;
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -103,6 +103,19 @@ Application::execute(const dataobj_t& cmd_data)
     m_runinfo.set_running(false);
     m_runinfo.set_run_number(0);
     m_runinfo.set_run_time(0);
+  } else if (cmdname == "conf" || cmdname == "reload") { // Does not
+                                                         // belong
+                                                         // here, just
+                                                         // hacked
+                                                         // in for testing!!!
+    std::cout << "rc_cmd.data=" << rc_cmd.data << "\n";
+
+    std::string confspec{""};
+    if (rc_cmd.data.contains("confspec")) {
+      confspec = rc_cmd.data["confspec"];
+    }
+    get_config_manager()->reload(confspec);
+    m_mod_mgr.reload(*dynamic_cast<OpMonManager*>(this));
   }
 
   try {

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -40,6 +40,7 @@ ConfigurationManager::ConfigurationManager(std::string const& config_spec,
                                            std::string const& app_name,
                                            std::string const& session_name)
   : m_confdb(new conffwk::Configuration(config_spec))
+  , m_config_spec(config_spec)
   , m_app_name(app_name)
   , m_session_name(session_name)
 {
@@ -53,6 +54,102 @@ ConfigurationManager::ConfigurationManager(std::string const& config_spec,
   }
   m_helper = std::make_shared<appmodel::ConfigurationHelper>(m_session);
 }
+
+
+/// Reload OKS configuration -- try to do as little re-initialization
+/// as possible
+void
+ConfigurationManager::reload(const std::string& confspec)
+{
+  TLOG() << "reloading configuration";
+
+  std::set<std::string> modules;
+  for (const auto& mod : m_modules) {
+    modules.insert(mod->full_name());
+    TLOG_DBG(TLVL_MODULE) << "old module " << mod->full_name();
+  }
+
+  // Presumably we do want to allow connections to change but keep a
+  // note of the current ones just to report changes
+  std::set<std::string> old_connections;
+  for (auto con: m_networkconnections) {
+    old_connections.insert(con->full_name());
+    TLOG_DBG(TLVL_QUEUE) << "old net_con " << con->full_name();
+  }
+  for (auto con: m_queues) {
+    old_connections.insert(con->full_name());
+    TLOG_DBG(TLVL_QUEUE) << "old queue " << con->full_name();
+  }
+  m_networkconnections.clear();
+  m_queues.clear();
+
+  if (!confspec.empty()) {
+    m_config_spec = confspec;
+  }
+  m_confdb.reset(new conffwk::Configuration(m_config_spec));
+
+  m_session = m_confdb->get<confmodel::Session>(m_session_name);
+  if (m_session == nullptr) {
+    TLOG() << "Failed to get session " << m_session_name;
+    throw MissingComponent(ERS_HERE, "Session " + m_session_name);
+  }
+  m_helper = std::make_shared<appmodel::ConfigurationHelper>(m_session);
+
+  m_application = m_confdb->get<confmodel::DaqApplication>(m_app_name);
+  if (m_application == nullptr) {
+    TLOG() << "Failed to get app " << m_app_name;
+    throw MissingComponent(ERS_HERE, "Application " + m_app_name);
+  }
+
+  TLOG_DBG(TLVL_APP) << "getting modules for app " << m_app_name;
+  auto smart_daq_app = m_application->cast<appmodel::SmartDaqApplication>();
+  if (smart_daq_app != nullptr) {
+    smart_daq_app->generate_modules(m_helper);
+  }
+ 
+  m_connsvc_config = m_session->get_connectivity_service();
+
+  m_modules = m_application->get_modules();
+  if (modules.size() != m_modules.size()) {
+    throw ModuleListChanged(ERS_HERE, "Application " + m_app_name);
+  }
+
+  std::set<std::string> connectionsAdded;
+  for (auto mod : m_modules) {
+    TLOG_DBG(TLVL_MODULE) << "new module " << mod->full_name();
+    if (!modules.contains(mod->full_name())) {
+      throw ModuleListChanged(ERS_HERE, "Application " + m_app_name);
+    }
+    TLOG_DBG(TLVL_MODULE) << "initialising connections for " << mod->class_name() << " module " << mod->UID();
+    auto connections = mod->get_inputs();
+    auto outputs = mod->get_outputs();
+    connections.insert(connections.end(), outputs.begin(), outputs.end());
+    for (auto con : connections) {
+      auto [c, inserted] = connectionsAdded.insert(con->UID());
+      if (!inserted) {
+        // Already handled this connection, don't add it again
+        continue;
+      }
+      auto queue = m_confdb->cast<confmodel::Queue>(con);
+      if (queue) {
+        if (!old_connections.contains(queue->full_name())) {
+          TLOG_DBG(TLVL_QUEUE) << "Adding new queue " << queue->UID();
+        }
+        m_queues.emplace_back(queue);
+      }
+      auto net_con = m_confdb->cast<confmodel::NetworkConnection>(con);
+      if (net_con) {
+        if (!old_connections.contains(net_con->full_name())) {
+          TLOG_DBG(TLVL_QUEUE) << "Adding new NetworkConnection " << net_con->UID();
+        }
+        m_networkconnections.emplace_back(net_con);
+      }
+    }
+  }
+
+  TLOG() << "configuration reloaded";
+}
+
 
 std::vector<ValidationReport>
 ConfigurationManager::initialize(bool throw_on_fatal)

--- a/src/DAQModuleManager.cpp
+++ b/src/DAQModuleManager.cpp
@@ -54,6 +54,18 @@ DAQModuleManager::initialize(std::shared_ptr<ConfigurationManager> cfgMgr, opmon
   this->m_initialized = true;
 }
 
+void
+DAQModuleManager::reload(opmonlib::OpMonManager& opm)
+{
+  get_iomanager()->reset();
+  get_iomanager()->configure(m_session_name,
+                             m_configuration_mgr->get_queues(),
+                             m_configuration_mgr->get_networkconnections(),
+                             m_configuration_mgr->get_connectivity_service(),
+                             opm);
+}
+
+
 std::optional<ValidationReport>
 DAQModuleManager::check_mod_has_cmd(const std::string& cmd,
                                     const std::string& mod_class,

--- a/src/DAQModuleManager.hpp
+++ b/src/DAQModuleManager.hpp
@@ -79,6 +79,7 @@ public:
   void initialize(std::shared_ptr<ConfigurationManager> mgr, opmonlib::OpMonManager&);
   bool initialized() const { return m_initialized; }
   void cleanup();
+  void reload(opmonlib::OpMonManager&);
 
   // Execute a properly structured command
   void execute(const std::string& cmd, const DAQModule::CommandData_t& cmd_data);


### PR DESCRIPTION
# Description
This is an exploration of what would be needed to implement reloading of the OKS configuration database. This includes re-running the `SmartDaqApplication::generate_modules()` method and comparison of the list of modules with the previously loaded configuartion etc.

This code is not intended to be merged in its current form!

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

